### PR TITLE
Refactor: Update schema naming, optimize data extraction based on data contracts, and fix API handlers

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -16,9 +16,16 @@ build:
 test:
 	go test ./... -v
 
-# Run the project.
-run:
-	go run .
+# Run the project (defaults to dev).
+run: run-dev
+
+# Run the project in development mode.
+run-dev:
+	ENV=dev go run .
+
+# Run the project in production mode.
+run-prod:
+	ENV=prod GIN_MODE=release go run .
 
 # Format the project source code.
 fmt:
@@ -95,9 +102,13 @@ docs-serve: docs
 execute-binary:
 	${BINARY_NAME}
 
-# Run the project with hot reload.
+# Run the project with hot reload(dev mode).
 dev:
-	$(shell go env GOPATH)/bin/air
+	ENV=dev $(shell go env GOPATH)/bin/air
+
+# Run the project with hot reload (prod mode).
+dev-prod:
+	ENV=prod GIN_MODE=release $(shell go env GOPATH)/bin/air
 
 # Build the migration tool.
 build-migrate:

--- a/api/dbqueries/language_queries.go
+++ b/api/dbqueries/language_queries.go
@@ -14,7 +14,7 @@ import (
 )
 
 // GetLanguageTableData fetches data for a specific language table.
-func GetLanguageTableData(lang, dataType string) (map[string]interface{}, error) {
+func GetLanguageTableData(lang, dataType string) (map[string]any, error) {
 	// Construct table name with the new format: ENLanguageDataNounsScribe
 
 	caser := cases.Title(language.English)
@@ -50,7 +50,7 @@ func GetLanguageTableData(lang, dataType string) (map[string]interface{}, error)
 		return nil, fmt.Errorf("error fetching data for %s: %w", tableName, err)
 	}
 
-	return map[string]interface{}{
+	return map[string]any{
 		"schema": schema,
 		"data":   data,
 	}, nil

--- a/api/dbqueries/language_queries.go
+++ b/api/dbqueries/language_queries.go
@@ -9,6 +9,8 @@ import (
 	"strings"
 
 	"github.com/scribe-org/scribe-server/database"
+	"golang.org/x/text/cases"
+	"golang.org/x/text/language"
 )
 
 // GetAvailableLanguages fetches all available languages from the database.
@@ -28,16 +30,36 @@ func GetLanguageVersions(lang string) (map[string]string, error) {
 
 // GetLanguageTableData fetches data for a specific language table.
 func GetLanguageTableData(lang, dataType string) (map[string]interface{}, error) {
-	// Construct table name.
-	tableName := fmt.Sprintf("%sLanguageData_%s", strings.ToUpper(lang), dataType)
+	// Construct table name with the new format: ENLanguageDataNounsScribe
 
-	// Get table schema.
+	caser := cases.Title(language.English)
+
+	tableName := fmt.Sprintf("%sLanguageData%sScribe",
+		strings.ToUpper(lang),
+		caser.String(dataType),
+	)
+
+	// Validate table name format and existence
+	if !isValidScribeTableName(tableName) {
+		return nil, fmt.Errorf("invalid table name format: %s", tableName)
+	}
+
+	// Check if table exists
+	exists, err := database.TableExists(tableName)
+	if err != nil {
+		return nil, fmt.Errorf("error checking table existence for %s: %w", tableName, err)
+	}
+	if !exists {
+		return nil, fmt.Errorf("table %s does not exist", tableName)
+	}
+
+	// Get table schema
 	schema, err := database.GetTableSchema(tableName)
 	if err != nil {
 		return nil, fmt.Errorf("error fetching schema for %s: %w", tableName, err)
 	}
 
-	// Get data from table.
+	// Get data from table
 	data, err := database.GetTableData(tableName)
 	if err != nil {
 		return nil, fmt.Errorf("error fetching data for %s: %w", tableName, err)
@@ -47,4 +69,51 @@ func GetLanguageTableData(lang, dataType string) (map[string]interface{}, error)
 		"schema": schema,
 		"data":   data,
 	}, nil
+}
+
+// isValidScribeTableName validates the table name follows the expected pattern.
+func isValidScribeTableName(tableName string) bool {
+	// Expected pattern: ENLanguageDataNounsScribe, FRLanguageDataVerbsScribe
+	if len(tableName) < 10 {
+		return false
+	}
+
+	// Check if it starts with 2-letter language code
+	if len(tableName) < 2 || !isAlpha(tableName[:2]) {
+		return false
+	}
+
+	// Check if it contains LanguageData
+	if !strings.Contains(tableName, "LanguageData") {
+		return false
+	}
+
+	// Check if it ends with Scribe
+	if !strings.HasSuffix(tableName, "Scribe") {
+		return false
+	}
+
+	// Only allow alphanumeric characters
+	for _, char := range tableName {
+		if !isAlphaNumeric(char) {
+			return false
+		}
+	}
+
+	return true
+}
+
+// isAlpha checks if string contains only alphabetic characters.
+func isAlpha(s string) bool {
+	for _, char := range s {
+		if !((char >= 'A' && char <= 'Z') || (char >= 'a' && char <= 'z')) {
+			return false
+		}
+	}
+	return true
+}
+
+// isAlphaNumeric checks if character is alphanumeric.
+func isAlphaNumeric(char rune) bool {
+	return (char >= 'A' && char <= 'Z') || (char >= 'a' && char <= 'z') || (char >= '0' && char <= '9')
 }

--- a/api/dbqueries/language_queries.go
+++ b/api/dbqueries/language_queries.go
@@ -13,21 +13,6 @@ import (
 	"golang.org/x/text/language"
 )
 
-// GetAvailableLanguages fetches all available languages from the database.
-func GetAvailableLanguages() ([]string, error) {
-	return database.GetAvailableLanguages()
-}
-
-// GetLanguageDataTypes fetches available data types for a specific language.
-func GetLanguageDataTypes(lang string) ([]string, error) {
-	return database.GetLanguageDataTypes(lang)
-}
-
-// GetLanguageVersions fetches version information for a specific language.
-func GetLanguageVersions(lang string) (map[string]string, error) {
-	return database.GetLanguageVersions(lang)
-}
-
 // GetLanguageTableData fetches data for a specific language table.
 func GetLanguageTableData(lang, dataType string) (map[string]interface{}, error) {
 	// Construct table name with the new format: ENLanguageDataNounsScribe
@@ -40,7 +25,7 @@ func GetLanguageTableData(lang, dataType string) (map[string]interface{}, error)
 	)
 
 	// Validate table name format and existence
-	if !isValidScribeTableName(tableName) {
+	if !database.IsValidTableName(tableName) {
 		return nil, fmt.Errorf("invalid table name format: %s", tableName)
 	}
 
@@ -69,51 +54,4 @@ func GetLanguageTableData(lang, dataType string) (map[string]interface{}, error)
 		"schema": schema,
 		"data":   data,
 	}, nil
-}
-
-// isValidScribeTableName validates the table name follows the expected pattern.
-func isValidScribeTableName(tableName string) bool {
-	// Expected pattern: ENLanguageDataNounsScribe, FRLanguageDataVerbsScribe
-	if len(tableName) < 10 {
-		return false
-	}
-
-	// Check if it starts with 2-letter language code
-	if len(tableName) < 2 || !isAlpha(tableName[:2]) {
-		return false
-	}
-
-	// Check if it contains LanguageData
-	if !strings.Contains(tableName, "LanguageData") {
-		return false
-	}
-
-	// Check if it ends with Scribe
-	if !strings.HasSuffix(tableName, "Scribe") {
-		return false
-	}
-
-	// Only allow alphanumeric characters
-	for _, char := range tableName {
-		if !isAlphaNumeric(char) {
-			return false
-		}
-	}
-
-	return true
-}
-
-// isAlpha checks if string contains only alphabetic characters.
-func isAlpha(s string) bool {
-	for _, char := range s {
-		if !((char >= 'A' && char <= 'Z') || (char >= 'a' && char <= 'z')) {
-			return false
-		}
-	}
-	return true
-}
-
-// isAlphaNumeric checks if character is alphanumeric.
-func isAlphaNumeric(char rune) bool {
-	return (char >= 'A' && char <= 'Z') || (char >= 'a' && char <= 'z') || (char >= '0' && char <= '9')
 }

--- a/api/dbqueries/language_queries.go
+++ b/api/dbqueries/language_queries.go
@@ -15,7 +15,7 @@ import (
 
 // GetLanguageTableData fetches data for a specific language table.
 func GetLanguageTableData(lang, dataType string) (map[string]any, error) {
-	// Construct table name with the new format: ENLanguageDataNounsScribe
+	// Construct table name with the new format: ENLanguageDataNounsScribe.
 
 	caser := cases.Title(language.English)
 
@@ -24,12 +24,12 @@ func GetLanguageTableData(lang, dataType string) (map[string]any, error) {
 		caser.String(dataType),
 	)
 
-	// Validate table name format and existence
+	// Validate table name format and existence.
 	if !database.IsValidTableName(tableName) {
 		return nil, fmt.Errorf("invalid table name format: %s", tableName)
 	}
 
-	// Check if table exists
+	// Check if table exists.
 	exists, err := database.TableExists(tableName)
 	if err != nil {
 		return nil, fmt.Errorf("error checking table existence for %s: %w", tableName, err)
@@ -38,13 +38,13 @@ func GetLanguageTableData(lang, dataType string) (map[string]any, error) {
 		return nil, fmt.Errorf("table %s does not exist", tableName)
 	}
 
-	// Get table schema
+	// Get table schema.
 	schema, err := database.GetTableSchema(tableName)
 	if err != nil {
 		return nil, fmt.Errorf("error fetching schema for %s: %w", tableName, err)
 	}
 
-	// Get data from table
+	// Get data from table.
 	data, err := database.GetTableData(tableName)
 	if err != nil {
 		return nil, fmt.Errorf("error fetching data for %s: %w", tableName, err)

--- a/api/handlers/common.go
+++ b/api/handlers/common.go
@@ -18,7 +18,7 @@ func HandleError(c *gin.Context, statusCode int, message string) {
 }
 
 // HandleSuccess sends a standardized success response.
-func HandleSuccess(c *gin.Context, data interface{}) {
+func HandleSuccess(c *gin.Context, data any) {
 	c.JSON(http.StatusOK, data)
 }
 

--- a/api/handlers/language.go
+++ b/api/handlers/language.go
@@ -12,6 +12,7 @@ import (
 	"github.com/gin-gonic/gin"
 	"github.com/scribe-org/scribe-server/api/dbqueries"
 	"github.com/scribe-org/scribe-server/api/validators"
+	"github.com/scribe-org/scribe-server/database"
 	"github.com/scribe-org/scribe-server/internal/constants"
 	"github.com/scribe-org/scribe-server/models"
 )
@@ -26,7 +27,7 @@ import (
 // @Failure 500 {object} models.ErrorResponse "Internal server error".
 // @Router /api/v1/languages [get]
 func GetAvailableLanguages(c *gin.Context) {
-	languages, err := dbqueries.GetAvailableLanguages()
+	languages, err := database.GetAvailableLanguages()
 	if err != nil {
 		log.Printf("Error fetching available languages: %v", err)
 		HandleError(c, http.StatusInternalServerError, constants.ErrorFetchingLanguages)
@@ -35,7 +36,7 @@ func GetAvailableLanguages(c *gin.Context) {
 
 	var languageInfos []models.LanguageInfo
 	for _, lang := range languages {
-		dataTypes, err := dbqueries.GetLanguageDataTypes(lang)
+		dataTypes, err := database.GetLanguageDataTypes(lang)
 		if err != nil {
 			log.Printf("Error fetching data types for %s: %v", lang, err)
 			continue
@@ -74,7 +75,7 @@ func GetLanguageData(c *gin.Context) {
 	}
 
 	// Check if language exists in database.
-	availableLanguages, err := dbqueries.GetAvailableLanguages()
+	availableLanguages, err := database.GetAvailableLanguages()
 	if err != nil {
 		log.Printf("Error checking available languages: %v", err)
 		HandleError(c, http.StatusInternalServerError, "Failed to check language availability")
@@ -87,7 +88,7 @@ func GetLanguageData(c *gin.Context) {
 	}
 
 	// Get data types for the language.
-	dataTypes, err := dbqueries.GetLanguageDataTypes(lang)
+	dataTypes, err := database.GetLanguageDataTypes(lang)
 	if err != nil {
 		log.Printf("Error fetching data types for %s: %v", lang, err)
 		HandleError(c, http.StatusInternalServerError, "Failed to fetch language data types")
@@ -154,7 +155,7 @@ func GetLanguageVersion(c *gin.Context) {
 	}
 
 	// Check if language exists in database.
-	availableLanguages, err := dbqueries.GetAvailableLanguages()
+	availableLanguages, err := database.GetAvailableLanguages()
 	if err != nil {
 		log.Printf("Error checking available languages: %v", err)
 		HandleError(c, http.StatusInternalServerError, "Failed to check language availability")
@@ -167,7 +168,7 @@ func GetLanguageVersion(c *gin.Context) {
 	}
 
 	// Get version information.
-	versions, err := dbqueries.GetLanguageVersions(lang)
+	versions, err := database.GetLanguageVersions(lang)
 	if err != nil {
 		log.Printf("Error fetching versions for %s: %v", lang, err)
 		HandleError(c, http.StatusInternalServerError, constants.ErrorFetchingLanguageVersions)

--- a/api/handlers/language.go
+++ b/api/handlers/language.go
@@ -227,10 +227,10 @@ func GetContracts(c *gin.Context) {
 	var err error
 
 	if lang != "" {
-		// Load a single language
+		// Load a single language.
 		contracts, err = loadSingleContract(contractsDir, lang)
 	} else {
-		// Load all languages
+		// Load all languages.
 		contracts, err = loadAllContracts(contractsDir)
 	}
 
@@ -271,7 +271,7 @@ func loadAllContracts(contractsDir string) (map[string]any, error) {
 	}
 
 	for _, file := range files {
-		// Skip directories and non-json files
+		// Skip directories and non-json files.
 		if file.IsDir() || filepath.Ext(file.Name()) != ".json" {
 			continue
 		}

--- a/api/handlers/language.go
+++ b/api/handlers/language.go
@@ -108,7 +108,7 @@ func GetLanguageData(c *gin.Context) {
 			UpdatedAt: time.Now().Format(constants.DateFormat),
 			Fields:    make(map[string]map[string]string),
 		},
-		Data: make(map[string]interface{}),
+		Data: make(map[string]any),
 	}
 
 	// For each data type, get schema and data.
@@ -223,7 +223,7 @@ func GetContracts(c *gin.Context) {
 		}
 	}
 
-	var contracts map[string]interface{}
+	var contracts map[string]any
 	var err error
 
 	if lang != "" {
@@ -246,24 +246,24 @@ func GetContracts(c *gin.Context) {
 }
 
 // loadSingleContract reads and unmarshals a single contract file.
-func loadSingleContract(contractsDir, lang string) (map[string]interface{}, error) {
+func loadSingleContract(contractsDir, lang string) (map[string]any, error) {
 	filePath := filepath.Join(contractsDir, lang+".json")
 	data, err := os.ReadFile(filePath)
 	if err != nil {
 		return nil, fmt.Errorf("could not read contract file for %s: %w", lang, err)
 	}
 
-	var contract interface{}
+	var contract any
 	if err := json.Unmarshal(data, &contract); err != nil {
 		return nil, fmt.Errorf("could not unmarshal contract for %s: %w", lang, err)
 	}
 
-	return map[string]interface{}{lang: contract}, nil
+	return map[string]any{lang: contract}, nil
 }
 
 // loadAllContracts reads and unmarshals all .json files in a directory.
-func loadAllContracts(contractsDir string) (map[string]interface{}, error) {
-	contracts := make(map[string]interface{})
+func loadAllContracts(contractsDir string) (map[string]any, error) {
+	contracts := make(map[string]any)
 
 	files, err := os.ReadDir(contractsDir)
 	if err != nil {
@@ -285,7 +285,7 @@ func loadAllContracts(contractsDir string) (map[string]interface{}, error) {
 			continue
 		}
 
-		var contract interface{}
+		var contract any
 		if err := json.Unmarshal(data, &contract); err != nil {
 			log.Printf("Warning: could not unmarshal contract file %s: %v", file.Name(), err)
 			continue

--- a/api/routes.go
+++ b/api/routes.go
@@ -19,6 +19,7 @@ func SetupRoutes(r *gin.Engine) {
 			v1.GET("/data/:lang", handlers.GetLanguageData)
 			v1.GET("/data-version/:lang", handlers.GetLanguageVersion)
 			v1.GET("/languages", handlers.GetAvailableLanguages)
+			v1.GET("/contracts", handlers.GetContracts)
 		}
 	}
 }

--- a/api/server.go
+++ b/api/server.go
@@ -36,6 +36,27 @@ func HandleRequests() {
 	// Create Gin router with default middleware (logger and recovery).
 	r := gin.Default()
 
+	// proxies trust security warning
+	trustedProxies := []string{} // Default empty (trusts nothing)
+	if os.Getenv("ENV") == "prod" {
+		// Trust RFC 1918 private network ranges commonly used by cloud providers and load balancers
+		trustedProxies = []string{
+			"10.0.0.0/8", // Class A private range (10.0.0.0 - 10.255.255.255)
+			// Used by: AWS VPC, Google Cloud, Kubernetes clusters, most cloud providers
+			"172.16.0.0/12", // Class B private range (172.16.0.0 - 172.31.255.255)
+			// Used by: Docker default bridge networks, some enterprise networks
+			"192.168.0.0/16", // Class C private range (192.168.0.0 - 192.168.255.255)
+			// Used by: Home routers, small office networks, some internal services
+		}
+		log.Printf("🔒 Production mode: trusting proxy networks")
+	} else {
+		log.Printf("🔒 Development mode: trusting no proxies")
+	}
+
+	if err := r.SetTrustedProxies(trustedProxies); err != nil {
+		log.Fatal(err)
+	}
+
 	// Add custom middleware.
 	r.Use(SetupCORS())
 

--- a/api/server.go
+++ b/api/server.go
@@ -23,11 +23,6 @@ func HandleRequests() {
 		log.Fatalf("Failed to initialize database: %v", err)
 	}
 
-	// Create language_data_versions table if it doesn't exist.
-	if err := database.CreateLanguageDataVersionsTable(); err != nil {
-		log.Printf("Warning: Failed to create language_data_versions table: %v", err)
-	}
-
 	// Set Gin mode based on environment.
 	switch viper.GetString("GIN_MODE") {
 	case "release":
@@ -96,10 +91,11 @@ func startServer(r *gin.Engine) {
 	validators.InitLanguageValidator(availableLanguages)
 
 	log.Printf("👀 Listening on port %s", hostPort)
-	log.Printf("🚀 API endpoints available:")
-	log.Printf("  ✅ GET /api/v1/data/:language_iso - Versioned API")
-	log.Printf("  ✅ GET /api/v1/data-version/:language_iso - Version check API")
-	log.Printf("  ✅ GET /api/v1/languages - List available languages")
+	log.Println("🚀 API Endpoints:")
+	log.Println("  ✅ GET /api/v1/languages                		- List available languages")
+	log.Println("  ✅ GET /api/v1/contracts[?lang_iso=xx]      	- Get contracts (optional language filter)")
+	log.Println("  ✅ GET /api/v1/data/:lang_iso       		- Get full language data with schema")
+	log.Println("  ✅ GET /api/v1/data-version/:lang_iso 		- Get version info for a language")
 	log.Printf("📊 Available languages: %v", availableLanguages)
 
 	log.Fatal(r.Run(hostPort))

--- a/api/server.go
+++ b/api/server.go
@@ -36,17 +36,17 @@ func HandleRequests() {
 	// Create Gin router with default middleware (logger and recovery).
 	r := gin.Default()
 
-	// proxies trust security warning
+	// Proxies trust security warning.
 	trustedProxies := []string{} // Default empty (trusts nothing)
 	if os.Getenv("ENV") == "prod" {
-		// Trust RFC 1918 private network ranges commonly used by cloud providers and load balancers
+		// Trust RFC 1918 private network ranges commonly used by cloud providers and load balancers.
 		trustedProxies = []string{
 			"10.0.0.0/8", // Class A private range (10.0.0.0 - 10.255.255.255)
-			// Used by: AWS VPC, Google Cloud, Kubernetes clusters, most cloud providers
+			// Note: Used by AWS VPC, Google Cloud, Kubernetes clusters, most cloud providers.
 			"172.16.0.0/12", // Class B private range (172.16.0.0 - 172.31.255.255)
-			// Used by: Docker default bridge networks, some enterprise networks
+			// Note: Used by Docker default bridge networks, some enterprise networks.
 			"192.168.0.0/16", // Class C private range (192.168.0.0 - 192.168.255.255)
-			// Used by: Home routers, small office networks, some internal services
+			// Note: Used by Home routers, small office networks, some internal services.
 		}
 		log.Printf("🔒 Production mode: trusting proxy networks")
 	} else {

--- a/api/validators/language_validator.go
+++ b/api/validators/language_validator.go
@@ -4,6 +4,7 @@
 package validators
 
 import (
+	"slices"
 	"strings"
 	"sync"
 )
@@ -49,10 +50,5 @@ func SanitizeLanguageCode(lang string) string {
 
 // IsLanguageSupported checks if a language exists in the provided list.
 func IsLanguageSupported(lang string, availableLanguages []string) bool {
-	for _, availableLang := range availableLanguages {
-		if availableLang == lang {
-			return true
-		}
-	}
-	return false
+	return slices.Contains(availableLanguages, lang)
 }

--- a/cmd/migrate/mariadb/queries.go
+++ b/cmd/migrate/mariadb/queries.go
@@ -33,7 +33,6 @@ func generateMariaTableName(langCode, tableName string) string {
 	// Clean up table name - replace underscores and capitalize properly
 	cleanTableName = strings.ReplaceAll(cleanTableName, "_", "")
 
-	// Use the proper cases package instead of deprecated strings.Title
 	caser := cases.Title(language.English)
 	cleanTableName = caser.String(cleanTableName)
 

--- a/cmd/migrate/mariadb/queries.go
+++ b/cmd/migrate/mariadb/queries.go
@@ -27,23 +27,23 @@ func ExecuteBatch(stmt *sql.Stmt, batch [][]interface{}) error {
 
 // generateMariaTableName creates the MariaDB table name with proper capitalization and suffixes.
 func generateMariaTableName(langCode, tableName string) string {
-	// Remove sqlite_ prefix if present
+	// Remove sqlite_ prefix if present.
 	cleanTableName := strings.TrimPrefix(tableName, "sqlite_")
 
-	// Clean up table name - replace underscores and capitalize properly
+	// Clean up table name - replace underscores and capitalize properly.
 	cleanTableName = strings.ReplaceAll(cleanTableName, "_", "")
 
 	caser := cases.Title(language.English)
 	cleanTableName = caser.String(cleanTableName)
 
-	// Special handling for TranslationData tables
+	// Special handling for TranslationData tables.
 	if strings.HasPrefix(langCode, "TranslationData") {
-		// For TranslationData, just use TranslationData + Language
+		// For TranslationData, just use TranslationData + Language:
 		// TranslationData + english -> TranslationDataEnglish
 		return "TranslationData" + cleanTableName
 	}
 
-	// For language data tables, capitalize table name and add Scribe suffix
+	// For language data tables, capitalize table name and add Scribe suffix:
 	// ENLanguageData + nouns -> ENLanguageDataNounsScribe
 	return langCode + cleanTableName + "Scribe"
 }

--- a/cmd/migrate/mariadb/queries.go
+++ b/cmd/migrate/mariadb/queries.go
@@ -11,6 +11,8 @@ import (
 
 	"github.com/scribe-org/scribe-server/cmd/migrate/schema"
 	"github.com/scribe-org/scribe-server/cmd/migrate/types"
+	"golang.org/x/text/cases"
+	"golang.org/x/text/language"
 )
 
 // ExecuteBatch executes a batch of SQL statements.
@@ -21,6 +23,30 @@ func ExecuteBatch(stmt *sql.Stmt, batch [][]interface{}) error {
 		}
 	}
 	return nil
+}
+
+// generateMariaTableName creates the MariaDB table name with proper capitalization and suffixes.
+func generateMariaTableName(langCode, tableName string) string {
+	// Remove sqlite_ prefix if present
+	cleanTableName := strings.TrimPrefix(tableName, "sqlite_")
+
+	// Clean up table name - replace underscores and capitalize properly
+	cleanTableName = strings.ReplaceAll(cleanTableName, "_", "")
+
+	// Use the proper cases package instead of deprecated strings.Title
+	caser := cases.Title(language.English)
+	cleanTableName = caser.String(cleanTableName)
+
+	// Special handling for TranslationData tables
+	if strings.HasPrefix(langCode, "TranslationData") {
+		// For TranslationData, just use TranslationData + Language
+		// TranslationData + english -> TranslationDataEnglish
+		return "TranslationData" + cleanTableName
+	}
+
+	// For language data tables, capitalize table name and add Scribe suffix
+	// ENLanguageData + nouns -> ENLanguageDataNounsScribe
+	return langCode + cleanTableName + "Scribe"
 }
 
 // MigrateTable migrates a single table from SQLite to MariaDB.
@@ -34,8 +60,8 @@ func MigrateTable(sqlite *sql.DB, mariaDB *sql.DB, langCode, tableName string) e
 	}
 
 	// Generate table names.
-	mariaTableName := fmt.Sprintf("%s_%s", langCode, strings.TrimPrefix(tableName, "sqlite_"))
-	backupTableName := mariaTableName + "_old"
+	mariaTableName := generateMariaTableName(langCode, tableName)
+	backupTableName := mariaTableName + "Old"
 
 	// Check if table exists and rename it to backup.
 	exists, err := tableExists(mariaDB, mariaTableName)

--- a/config-example.yaml
+++ b/config-example.yaml
@@ -1,5 +1,6 @@
 # hostPort: 8080
 # fileSystem: "./"
+# contractsDir: "./contracts"
 # database:
 #   user: root
 #   password: "password"

--- a/contracts/de.json
+++ b/contracts/de.json
@@ -1,0 +1,39 @@
+{
+  "numbers": { "nominativeSingular": "nominativePlural" },
+  "genders": {
+    "canonical": ["gender"],
+    "feminines": [],
+    "masculines": [],
+    "commons": [],
+    "neuters": []
+  },
+  "conjugations": {
+    "1": {
+      "title": "Präsens",
+      "1": { "ich": "indicativePresentFirstPersonSingular" },
+      "2": { "du": "indicativePresentSecondPersonSingular" },
+      "3": { "er/sie/es": "indicativePresentThirdPersonSingular" },
+      "4": { "wir": "indicativePresentFirstPersonPlural" },
+      "5": { "ihr": "indicativePresentSecondPersonPlural" },
+      "6": { "sie/Sie": "indicativePresentThirdPersonPlural" }
+    },
+    "2": {
+      "title": "Preterite",
+      "1": { "ich": "indicativePreteriteFirstPersonSingular" },
+      "2": { "du": "indicativePreteriteFirstPersonPlural" },
+      "3": { "er/sie/es": "indicativePreteriteSecondPersonSingular" },
+      "4": { "wir": "indicativePreteriteSecondPersonPlural" },
+      "5": { "ihr": "indicativePreteriteThirdPersonSingular" },
+      "6": { "sie/Sie": "indicativePreteriteThirdPersonPlural" }
+    },
+    "3": {
+      "title": "Perfekt",
+      "1": { "ich": "[auxiliaryVerb] pastParticiple" },
+      "2": { "du": "[auxiliaryVerb] pastParticiple" },
+      "3": { "er/sie/es": "[auxiliaryVerb] pastParticiple" },
+      "4": { "wir": "[auxiliaryVerb] pastParticiple" },
+      "5": { "ihr": "[auxiliaryVerb] pastParticiple" },
+      "6": { "sie/Sie": "[auxiliaryVerb] pastParticiple" }
+    }
+  }
+}

--- a/contracts/en.json
+++ b/contracts/en.json
@@ -1,0 +1,48 @@
+{
+  "numbers": { "singular": "plural" },
+  "genders": {
+    "canonical": ["NOT_INCLUDED"],
+    "feminines": ["NOT_INCLUDED"],
+    "masculines": ["NOT_INCLUDED"],
+    "commons": ["NOT_INCLUDED"],
+    "neuters": ["NOT_INCLUDED"]
+  },
+  "conjugations": {
+    "1": {
+      "title": "Present",
+      "1": { "I": "simplePresent" },
+      "2": { "you": "simplePresent" },
+      "3": { "he/she/it": "simplePresentThirdPersonSingular" },
+      "4": { "we": "simplePresent" },
+      "5": { "you all": "simplePresent" },
+      "6": { "they": "simplePresent" }
+    },
+    "2": {
+      "title": "Past",
+      "1": { "I": "simplePast" },
+      "2": { "you": "simplePast" },
+      "3": { "he/she/it": "simplePast" },
+      "4": { "we": "simplePast" },
+      "5": { "you all": "simplePast" },
+      "6": { "they": "simplePast" }
+    },
+    "3": {
+      "title": "Perfect",
+      "1": { "I": "combinedPresentParticiple simplePast" },
+      "2": { "you": "combinedPresentParticiple simplePast" },
+      "3": { "he/she/it": "combinedPresentParticiple simplePast" },
+      "4": { "we": "combinedPresentParticiple simplePast" },
+      "5": { "you all": "combinedPresentParticiple simplePast" },
+      "6": { "they": "combinedPresentParticiple simplePast" }
+    },
+    "4": {
+      "title": "Past Perfect",
+      "1": { "I": "pastParticiple simplePast" },
+      "2": { "you": "pastParticiple simplePast" },
+      "3": { "he/she/it": "pastParticiple simplePast" },
+      "4": { "we": "pastParticiple simplePast" },
+      "5": { "you all": "pastParticiple simplePast" },
+      "6": { "they": "pastParticiple simplePast" }
+    }
+  }
+}

--- a/contracts/es.json
+++ b/contracts/es.json
@@ -1,0 +1,42 @@
+{
+  "numbers": {
+    "feminineSingular": "femininePlural",
+    "masculineSingular": "masculinePlural"
+  },
+  "genders": {
+    "canonical": [],
+    "feminines": ["feminineSingular"],
+    "masculines": ["masculineSingular"],
+    "commons": [],
+    "neuters": []
+  },
+  "conjugations": {
+    "1": {
+      "title": "Presente",
+      "1": { "yo": "indicativePresentFirstPersonSingular" },
+      "2": { "tú": "indicativePresentFirstPersonPlural" },
+      "3": { "él/ella/Ud.": "indicativePresentSecondPersonSingular" },
+      "4": { "nosotros": "indicativePresentSecondPersonPlural" },
+      "5": { "vosotros": "indicativePresentThirdPersonSingular" },
+      "6": { "ellos/ellas/Uds.": "indicativePresentThirdPersonPlural" }
+    },
+    "2": {
+      "title": "Pretérito",
+      "1": { "yo": "preteriteFirstPersonSingular" },
+      "2": { "tú": "preteriteFirstPersonPlural" },
+      "3": { "él/ella/Ud.": "preteriteSecondPersonSingular" },
+      "4": { "nosotros": "preteriteSecondPersonPlural" },
+      "5": { "vosotros": "preteriteThirdPersonSingular" },
+      "6": { "ellos/ellas/Uds.": "preteriteThirdPersonPlural" }
+    },
+    "3": {
+      "title": "Imperfecto",
+      "1": { "yo": "pastImperfectFirstPersonSingular" },
+      "2": { "tú": "pastImperfectFirstPersonPlural" },
+      "3": { "él/ella/Ud.": "pastImperfectSecondPersonSingular" },
+      "4": { "nosotros": "pastImperfectSecondPersonPlural" },
+      "5": { "vosotros": "pastImperfectThirdPersonSingular" },
+      "6": { "ellos/ellas/Uds.": "pastImperfectThirdPersonPlural" }
+    }
+  }
+}

--- a/contracts/fr.json
+++ b/contracts/fr.json
@@ -1,0 +1,48 @@
+{
+  "numbers": { "singular": "plural" },
+  "genders": {
+    "canonical": ["gender"],
+    "feminines": [],
+    "masculines": [],
+    "commons": [],
+    "neuters": []
+  },
+  "conjugations": {
+    "1": {
+      "title": "Présent",
+      "1": { "je": "indicativePresentFirstPersonSingular" },
+      "2": { "tu": "indicativePresentFirstPersonPlural" },
+      "3": { "il/elle": "indicativePresentSecondPersonSingular" },
+      "4": { "nous": "indicativePresentSecondPersonPlural" },
+      "5": { "vous": "indicativePresentThirdPersonSingular" },
+      "6": { "ils/elles": "indicativePresentThirdPersonPlural" }
+    },
+    "2": {
+      "title": "Passé simple",
+      "1": { "je": "indicativePreteriteFirstPersonSingular" },
+      "2": { "tu": "indicativePreteriteFirstPersonPlural" },
+      "3": { "il/elle": "indicativePreteriteSecondPersonSingular" },
+      "4": { "nous": "indicativePreteriteSecondPersonPlural" },
+      "5": { "vous": "indicativePreteriteThirdPersonSingular" },
+      "6": { "ils/elles": "indicativePreteriteThirdPersonPlural" }
+    },
+    "3": {
+      "title": "Imparfait",
+      "1": { "je": "indicativeImperfectFirstPersonSingular" },
+      "2": { "tu": "indicativeImperfectFirstPersonPlural" },
+      "3": { "il/elle": "indicativeImperfectSecondPersonSingular" },
+      "4": { "nous": "indicativeImperfectSecondPersonPlural" },
+      "5": { "vous": "indicativeImperfectThirdPersonSingular" },
+      "6": { "ils/elles": "indicativeImperfectThirdPersonPlural" }
+    },
+    "4": {
+      "title": "Futur",
+      "1": { "je": "indicativeSimpleFutureFirstPersonSingular" },
+      "2": { "tu": "indicativeSimpleFutureFirstPersonPlural" },
+      "3": { "il/elle": "indicativeSimpleFutureSecondPersonSingular" },
+      "4": { "nous": "indicativeSimpleFutureSecondPersonPlural" },
+      "5": { "vous": "indicativeSimpleFutureThirdPersonSingular" },
+      "6": { "ils/elles": "indicativeSimpleFutureThirdPersonPlural" }
+    }
+  }
+}

--- a/contracts/it.json
+++ b/contracts/it.json
@@ -1,0 +1,39 @@
+{
+  "numbers": { "singular": "plural" },
+  "genders": {
+    "canonical": ["gender"],
+    "feminines": [],
+    "masculines": [],
+    "commons": [],
+    "neuters": []
+  },
+  "conjugations": {
+    "1": {
+      "title": "Presente",
+      "1": { "io": "presentIndicativeFirstPersonSingular" },
+      "2": { "tu": "presentIndicativeFirstPersonPlural" },
+      "3": { "lei/lui": "presentIndicativeSecondPersonSingular" },
+      "4": { "noi": "presentIndicativeSecondPersonPlural" },
+      "5": { "voi": "presentIndicativeThirdPersonSingular" },
+      "6": { "loro": "presentIndicativeThirdPersonPlural" }
+    },
+    "2": {
+      "title": "Preterito",
+      "1": { "io": "preteriteFirstPersonSingular" },
+      "2": { "tu": "preteriteFirstPersonPlural" },
+      "3": { "lei/lui": "preteriteSecondPersonSingular" },
+      "4": { "noi": "preteriteSecondPersonPlural" },
+      "5": { "voi": "preteriteThirdPersonSingular" },
+      "6": { "loro": "preteriteThirdPersonPlural" }
+    },
+    "3": {
+      "title": "Imperfetto",
+      "1": { "io": "pastImperfectFirstPersonSingular" },
+      "2": { "tu": "pastImperfectFirstPersonPlural" },
+      "3": { "lei/lui": "pastImperfectSecondPersonSingular" },
+      "4": { "noi": "pastImperfectSecondPersonPlural" },
+      "5": { "voi": "pastImperfectThirdPersonSingular" },
+      "6": { "loro": "pastImperfectThirdPersonPlural" }
+    }
+  }
+}

--- a/contracts/pt.json
+++ b/contracts/pt.json
@@ -1,0 +1,48 @@
+{
+  "numbers": { "singular": "plural" },
+  "genders": {
+    "canonical": ["gender"],
+    "feminines": [],
+    "masculines": [],
+    "commons": [],
+    "neuters": []
+  },
+  "conjugations": {
+    "1": {
+      "title": "Presente",
+      "1": { "eu": "indicativePresentFirstPersonSingular" },
+      "2": { "tu": "indicativePresentFirstPersonPlural" },
+      "3": { "ele/ela/você": "indicativePresentSecondPersonSingular" },
+      "4": { "nós": "indicativePresentSecondPersonPlural" },
+      "5": { "vós": "indicativePresentThirdPersonSingular" },
+      "6": { "eles/elas/vocês": "indicativePresentThirdPersonPlural" }
+    },
+    "2": {
+      "title": "Pretérito Perfeito",
+      "1": { "eu": "indicativePastPerfectFirstPersonSingular" },
+      "2": { "tu": "indicativePastPerfectFirstPersonPlural" },
+      "3": { "ele/ela/você": "indicativePastPerfectSecondPersonSingular" },
+      "4": { "nós": "indicativePastPerfectSecondPersonPlural" },
+      "5": { "vós": "indicativePastPerfectThirdPersonSingular" },
+      "6": { "eles/elas/vocês": "indicativePastPerfectThirdPersonPlural" }
+    },
+    "3": {
+      "title": "Pretérito Imperfeito",
+      "1": { "eu": "indicativePastImperfectFirstPersonSingular" },
+      "2": { "tu": "indicativePastImperfectFirstPersonPlural" },
+      "3": { "ele/ela/você": "indicativePastImperfectSecondPersonSingular" },
+      "4": { "nós": "indicativePastImperfectSecondPersonPlural" },
+      "5": { "vós": "indicativePastImperfectThirdPersonSingular" },
+      "6": { "eles/elas/vocês": "indicativePastImperfectThirdPersonPlural" }
+    },
+    "4": {
+      "title": "Futuro Simples",
+      "1": { "eu": "indicativePluperfectFirstPersonSingular" },
+      "2": { "tu": "indicativePluperfectFirstPersonPlural" },
+      "3": { "ele/ela/você": "indicativePluperfectSecondPersonSingular" },
+      "4": { "nós": "indicativePluperfectSecondPersonPlural" },
+      "5": { "vós": "indicativePluperfectThirdPersonSingular" },
+      "6": { "eles/elas/vocês": "indicativePluperfectThirdPersonPlural" }
+    }
+  }
+}

--- a/contracts/ru.json
+++ b/contracts/ru.json
@@ -1,0 +1,28 @@
+{
+  "numbers": { "nominativeSingular": "nominativePlural" },
+  "genders": {
+    "canonical": ["gender"],
+    "feminines": [],
+    "masculines": [],
+    "commons": [],
+    "neuters": []
+  },
+  "conjugations": {
+    "1": {
+      "title": "Настоящее",
+      "1": { "я": "indicativePresentFirstPersonSingular" },
+      "2": { "ты": "indicativePresentFirstPersonPlural" },
+      "3": { "он/она/оно": "indicativePresentSecondPersonSingular" },
+      "4": { "мы": "indicativePresentSecondPersonPlural" },
+      "5": { "вы": "indicativePresentThirdPersonSingular" },
+      "6": { "они": "indicativePresentThirdPersonPlural" }
+    },
+    "2": {
+      "title": "Прошедшее",
+      "1": { "я/ты/она": "feminineIndicativePast" },
+      "2": { "я/ты/он": "masculineIndicativePast" },
+      "3": { "оно": "neuterIndicativePast" },
+      "4": { "мы/вы/они": "indicativePastPlural" }
+    }
+  }
+}

--- a/contracts/sv.json
+++ b/contracts/sv.json
@@ -1,0 +1,29 @@
+{
+  "numbers": {
+    "nominativeIndefiniteSingular": "nominativeIndefinitePlural",
+    "nominativeDefiniteSingular": "nominativeDefinitePlural"
+  },
+  "genders": {
+    "canonical": ["gender"],
+    "feminines": [],
+    "masculines": [],
+    "commons": [],
+    "neuters": []
+  },
+  "conjugations": {
+    "1": {
+      "title": "Aktiv",
+      "1": { "": "activeInfinitive" },
+      "2": { "": "activePresent" },
+      "3": { "": "activePreterite" },
+      "4": { "": "activeSupine" }
+    },
+    "2": {
+      "title": "Passiv",
+      "1": { "": "passiveInfinitive" },
+      "2": { "": "passivePresent" },
+      "3": { "": "passivePreterite" },
+      "4": { "": "passiveSupine" }
+    }
+  }
+}

--- a/database/language.go
+++ b/database/language.go
@@ -14,8 +14,8 @@ import (
 func GetAvailableLanguages() ([]string, error) {
 	query := `
 		SELECT DISTINCT SUBSTRING(TABLE_NAME, 1, 2) as language_code
-		FROM information_schema.TABLES 
-		WHERE TABLE_SCHEMA = ? 
+		FROM information_schema.TABLES
+		WHERE TABLE_SCHEMA = ?
 		AND TABLE_NAME LIKE '%LanguageData%Scribe'
 		ORDER BY language_code
 	`
@@ -48,8 +48,8 @@ func GetLanguageDataTypes(lang string) ([]string, error) {
 
 	query := `
 		SELECT TABLE_NAME
-		FROM information_schema.TABLES 
-		WHERE TABLE_SCHEMA = ? 
+		FROM information_schema.TABLES
+		WHERE TABLE_SCHEMA = ?
 		AND TABLE_NAME LIKE ?
 		ORDER BY TABLE_NAME
 	`
@@ -61,7 +61,7 @@ func GetLanguageDataTypes(lang string) ([]string, error) {
 	defer rows.Close()
 
 	var dataTypes []string
-	// Regex to extract data type from table name like ENLanguageDataNounsScribe
+	// Regex to extract data type from table name like ENLanguageDataNounsScribe.
 	re := regexp.MustCompile(`^[A-Z]{2}LanguageData([A-Za-z]+)Scribe$`)
 
 	for rows.Next() {
@@ -72,7 +72,7 @@ func GetLanguageDataTypes(lang string) ([]string, error) {
 
 		matches := re.FindStringSubmatch(tableName)
 		if len(matches) > 1 {
-			dataType := strings.ToLower(matches[1]) // Convert to lowercase (nouns, verbs)
+			dataType := strings.ToLower(matches[1]) // convert to lowercase (nouns, verbs)
 			dataTypes = append(dataTypes, dataType)
 		}
 	}

--- a/database/table.go
+++ b/database/table.go
@@ -60,7 +60,7 @@ func GetTableSchema(tableName string) (map[string]string, error) {
 
 // GetTableData retrieves all rows and columns from a given table.
 // The result is a slice of maps, where each map represents a row with column-value pairs.
-func GetTableData(tableName string) ([]map[string]interface{}, error) {
+func GetTableData(tableName string) ([]map[string]any, error) {
 	if !IsValidTableName(tableName) {
 		return nil, fmt.Errorf("invalid table name")
 	}
@@ -78,11 +78,11 @@ func GetTableData(tableName string) ([]map[string]interface{}, error) {
 		return nil, fmt.Errorf("error getting columns: %w", err)
 	}
 
-	var results []map[string]interface{}
+	var results []map[string]any
 
 	for rows.Next() {
-		values := make([]interface{}, len(columns))
-		valuePtrs := make([]interface{}, len(columns))
+		values := make([]any, len(columns))
+		valuePtrs := make([]any, len(columns))
 		for i := range columns {
 			valuePtrs[i] = &values[i]
 		}
@@ -90,7 +90,7 @@ func GetTableData(tableName string) ([]map[string]interface{}, error) {
 			return nil, fmt.Errorf("error scanning row: %w", err)
 		}
 
-		rowMap := make(map[string]interface{})
+		rowMap := make(map[string]any)
 		for i, col := range columns {
 			val := values[i]
 			if val == nil {

--- a/database/table.go
+++ b/database/table.go
@@ -8,6 +8,24 @@ import (
 	"github.com/spf13/viper"
 )
 
+// TableExists checks if a table exists in the database.
+func TableExists(tableName string) (bool, error) {
+	query := `
+		SELECT COUNT(*) 
+		FROM information_schema.TABLES 
+		WHERE TABLE_SCHEMA = ? 
+		AND TABLE_NAME = ?
+	`
+
+	var count int
+	err := DB.QueryRow(query, viper.GetString("database.name"), tableName).Scan(&count)
+	if err != nil {
+		return false, fmt.Errorf("error checking table existence: %w", err)
+	}
+
+	return count > 0, nil
+}
+
 // GetTableSchema returns the column names and types for a specific table
 // in the connected MySQL/MariaDB database.
 func GetTableSchema(tableName string) (map[string]string, error) {
@@ -87,4 +105,9 @@ func GetTableData(tableName string) ([]map[string]interface{}, error) {
 	}
 
 	return results, nil
+}
+
+// isAlphaNumeric checks if character is alphanumeric.
+func isAlphaNumeric(char rune) bool {
+	return (char >= 'A' && char <= 'Z') || (char >= 'a' && char <= 'z') || (char >= '0' && char <= '9')
 }

--- a/database/table.go
+++ b/database/table.go
@@ -29,7 +29,7 @@ func TableExists(tableName string) (bool, error) {
 // GetTableSchema returns the column names and types for a specific table
 // in the connected MySQL/MariaDB database.
 func GetTableSchema(tableName string) (map[string]string, error) {
-	if !isValidTableName(tableName) {
+	if !IsValidTableName(tableName) {
 		return nil, fmt.Errorf("invalid table name")
 	}
 
@@ -61,7 +61,7 @@ func GetTableSchema(tableName string) (map[string]string, error) {
 // GetTableData retrieves all rows and columns from a given table.
 // The result is a slice of maps, where each map represents a row with column-value pairs.
 func GetTableData(tableName string) ([]map[string]interface{}, error) {
-	if !isValidTableName(tableName) {
+	if !IsValidTableName(tableName) {
 		return nil, fmt.Errorf("invalid table name")
 	}
 
@@ -105,9 +105,4 @@ func GetTableData(tableName string) ([]map[string]interface{}, error) {
 	}
 
 	return results, nil
-}
-
-// isAlphaNumeric checks if character is alphanumeric.
-func isAlphaNumeric(char rune) bool {
-	return (char >= 'A' && char <= 'Z') || (char >= 'a' && char <= 'z') || (char >= '0' && char <= '9')
 }

--- a/database/utils.go
+++ b/database/utils.go
@@ -10,19 +10,19 @@ import (
 
 // IsValidTableName validates table names to prevent SQL injection.
 func IsValidTableName(tableName string) bool {
-	// Pattern to match the new table structure: ENLanguageDataNounsScribe
+	// Pattern to match the new table structure: ENLanguageDataNounsScribe.
 	pattern := `^[A-Z]{2}LanguageData[A-Za-z]+Scribe$`
 	matched, err := regexp.MatchString(pattern, tableName)
 	if err != nil {
 		return false
 	}
 
-	// Additional length check
+	// Additional length check.
 	if len(tableName) > 100 || len(tableName) < 10 {
 		return false
 	}
 
-	// Check for only alphanumeric characters (no special chars that could be used for injection)
+	// Check for only alphanumeric characters (no special chars that could be used for injection).
 	for _, char := range tableName {
 		if !constants.IsAlphaNumeric(char) {
 			return false

--- a/database/utils.go
+++ b/database/utils.go
@@ -2,10 +2,14 @@
 
 package database
 
-import "regexp"
+import (
+	"regexp"
 
-// isValidTableName validates table names to prevent SQL injection.
-func isValidTableName(tableName string) bool {
+	"github.com/scribe-org/scribe-server/internal/constants"
+)
+
+// IsValidTableName validates table names to prevent SQL injection.
+func IsValidTableName(tableName string) bool {
 	// Pattern to match the new table structure: ENLanguageDataNounsScribe
 	pattern := `^[A-Z]{2}LanguageData[A-Za-z]+Scribe$`
 	matched, err := regexp.MatchString(pattern, tableName)
@@ -20,7 +24,7 @@ func isValidTableName(tableName string) bool {
 
 	// Check for only alphanumeric characters (no special chars that could be used for injection)
 	for _, char := range tableName {
-		if !isAlphaNumeric(char) {
+		if constants.IsAlphaNumeric(char) {
 			return false
 		}
 	}

--- a/database/utils.go
+++ b/database/utils.go
@@ -24,7 +24,7 @@ func IsValidTableName(tableName string) bool {
 
 	// Check for only alphanumeric characters (no special chars that could be used for injection)
 	for _, char := range tableName {
-		if constants.IsAlphaNumeric(char) {
+		if !constants.IsAlphaNumeric(char) {
 			return false
 		}
 	}

--- a/database/utils.go
+++ b/database/utils.go
@@ -2,14 +2,28 @@
 
 package database
 
+import "regexp"
+
+// isValidTableName validates table names to prevent SQL injection.
 func isValidTableName(tableName string) bool {
+	// Pattern to match the new table structure: ENLanguageDataNounsScribe
+	pattern := `^[A-Z]{2}LanguageData[A-Za-z]+Scribe$`
+	matched, err := regexp.MatchString(pattern, tableName)
+	if err != nil {
+		return false
+	}
+
+	// Additional length check
+	if len(tableName) > 100 || len(tableName) < 10 {
+		return false
+	}
+
+	// Check for only alphanumeric characters (no special chars that could be used for injection)
 	for _, char := range tableName {
-		if !((char >= 'a' && char <= 'z') ||
-			(char >= 'A' && char <= 'Z') ||
-			(char >= '0' && char <= '9') ||
-			char == '_') {
+		if !isAlphaNumeric(char) {
 			return false
 		}
 	}
-	return len(tableName) > 0 && len(tableName) <= 64
+
+	return matched
 }

--- a/database/versions.go
+++ b/database/versions.go
@@ -8,6 +8,8 @@ import (
 	"strings"
 
 	"github.com/spf13/viper"
+	"golang.org/x/text/cases"
+	"golang.org/x/text/language"
 )
 
 // CreateLanguageDataVersionsTable creates the `language_data_versions` table if it does not already exist.
@@ -59,7 +61,8 @@ func GetLanguageVersions(lang string) (map[string]string, error) {
 
 	for _, dataType := range dataTypes {
 		// Construct the actual table name format: ENLanguageDataNounsScribe
-		tableName := fmt.Sprintf("%sLanguageData%sScribe", langPrefix, strings.Title(dataType))
+		c := cases.Title(language.Und)
+		tableName := fmt.Sprintf("%sLanguageData%sScribe", langPrefix, c.String(dataType))
 
 		// Check if table exists and has lastModified column
 		schemaQuery := `

--- a/database/versions.go
+++ b/database/versions.go
@@ -60,28 +60,28 @@ func GetLanguageVersions(lang string) (map[string]string, error) {
 	langPrefix := strings.ToUpper(lang)
 
 	for _, dataType := range dataTypes {
-		// Construct the actual table name format: ENLanguageDataNounsScribe
+		// Construct the actual table name format: ENLanguageDataNounsScribe.
 		c := cases.Title(language.Und)
 		tableName := fmt.Sprintf("%sLanguageData%sScribe", langPrefix, c.String(dataType))
 
-		// Check if table exists and has lastModified column
+		// Check if table exists and has lastModified column.
 		schemaQuery := `
-			SELECT COUNT(*) 
-			FROM information_schema.COLUMNS 
-			WHERE TABLE_SCHEMA = ? 
-			AND TABLE_NAME = ? 
+			SELECT COUNT(*)
+			FROM information_schema.COLUMNS
+			WHERE TABLE_SCHEMA = ?
+			AND TABLE_NAME = ?
 			AND COLUMN_NAME = 'lastModified'
 		`
 
 		var columnExists int
 		err := DB.QueryRow(schemaQuery, viper.GetString("database.name"), tableName).Scan(&columnExists)
 		if err != nil || columnExists == 0 {
-			// If lastModified column doesn't exist, use a default date
+			// If lastModified column doesn't exist, use a default date.
 			versions[dataType+"_last_modified"] = "1970-01-01"
 			continue
 		}
 
-		// Query to get the maximum lastModified date from the table
+		// Query to get the maximum lastModified date from the table.
 		query := fmt.Sprintf(`
 			SELECT COALESCE(MAX(lastModified), '1970-01-01') as max_last_modified
 			FROM %s
@@ -90,7 +90,7 @@ func GetLanguageVersions(lang string) (map[string]string, error) {
 		var lastModified string
 		err = DB.QueryRow(query).Scan(&lastModified)
 		if err != nil {
-			// If there's an error, use a default date
+			// If there's an error, use a default date.
 			lastModified = "1970-01-01"
 		}
 

--- a/internal/constants/strings.go
+++ b/internal/constants/strings.go
@@ -1,0 +1,11 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+// Package constants provides shared, reusable constant values across the application.
+package constants
+
+import "unicode"
+
+// IsAlphaNumeric checks if character is alphanumeric.
+func IsAlphaNumeric(char rune) bool {
+	return unicode.IsLetter(char) || unicode.IsDigit(char)
+}

--- a/main.go
+++ b/main.go
@@ -50,6 +50,7 @@ func main() {
 			panic(fmt.Errorf("fatal error config file: %w", err))
 		}
 	}
+	viper.SetDefault("contractsDir", "./contracts")
 
 	api.HandleRequests()
 }

--- a/models/models.go
+++ b/models/models.go
@@ -47,3 +47,8 @@ type LanguageInfo struct {
 type AvailableLanguagesResponse struct {
 	Languages []LanguageInfo `json:"languages"`
 }
+
+// ContractsResponse represents the response for contracts available for languages
+type ContractsResponse struct {
+	Contracts map[string]interface{} `json:"contracts"`
+}

--- a/models/models.go
+++ b/models/models.go
@@ -48,7 +48,7 @@ type AvailableLanguagesResponse struct {
 	Languages []LanguageInfo `json:"languages"`
 }
 
-// ContractsResponse represents the response for contracts available for languages
+// ContractsResponse represents the response for contracts available for languages.
 type ContractsResponse struct {
 	Contracts map[string]any `json:"contracts"`
 }

--- a/models/models.go
+++ b/models/models.go
@@ -19,9 +19,9 @@ type Contract struct {
 
 // LanguageDataResponse represents the full language data response.
 type LanguageDataResponse struct {
-	Language string                 `json:"language"`
-	Contract Contract               `json:"contract"`
-	Data     map[string]interface{} `json:"data"`
+	Language string         `json:"language"`
+	Contract Contract       `json:"contract"`
+	Data     map[string]any `json:"data"`
 }
 
 // LanguageVersionResponse represents version information for a language.
@@ -50,5 +50,5 @@ type AvailableLanguagesResponse struct {
 
 // ContractsResponse represents the response for contracts available for languages
 type ContractsResponse struct {
-	Contracts map[string]interface{} `json:"contracts"`
+	Contracts map[string]any `json:"contracts"`
 }

--- a/update_data.sh
+++ b/update_data.sh
@@ -22,7 +22,7 @@ TARGET_LANGUAGES=("english" "french" "german" "italian" "spanish" "portuguese" "
 # TARGET_LANGUAGES=("english" "french")
 
 
-DATA_TYPES=("adjectives" "adverbs" "conjunctions" "emoji-keywords" "nouns" "personal-pronouns" "postpositions" "prepositions" "pronouns" "proper-nouns" "verbs")
+DATA_TYPES=("adjectives" "adverbs" "conjunctions" "nouns" "personal_pronouns" "postpositions" "prepositions" "pronouns" "proper_nouns" "verbs")
 
 # FOR TESTING PURPOSES
 # DATA_TYPES=("nouns" "verbs")

--- a/update_data.sh
+++ b/update_data.sh
@@ -15,6 +15,18 @@ SKIP_MIGRATION=${1:-false}
 # Save project root.
 PROJECT_ROOT=$(pwd)
 
+# Define target languages and data types
+TARGET_LANGUAGES=("english" "french" "german" "italian" "spanish" "portuguese" "russian" "swedish")
+
+# FOR TESTING PURPOSES
+# TARGET_LANGUAGES=("english" "french")
+
+
+DATA_TYPES=("adjectives" "adverbs" "conjunctions" "emoji-keywords" "nouns" "personal-pronouns" "postpositions" "prepositions" "pronouns" "proper-nouns" "verbs")
+
+# FOR TESTING PURPOSES
+# DATA_TYPES=("nouns" "verbs")
+
 # Colors for output.
 RED='\033[0;31m'
 GREEN='\033[0;32m'
@@ -127,23 +139,118 @@ pip install -e . || {
 }
 success "Dependencies installed successfully"
 
-# MARK: Gen Data
+# MARK: Download Wikidata Dump First
 
-log "⚡ Generating language data (auto-confirm)..."
-yes y | scribe-data get -a -wdp || {
-    error "Failed to generate language data"
-    exit 1
-}
+DUMP_DIR="./scribe_data_wikidata_dumps_export"
+DUMP_FILE="$DUMP_DIR/latest-lexemes.json.bz2"
+
+if [ ! -f "$DUMP_FILE" ]; then
+    log "📥 Downloading Wikidata lexeme dump..."
+    # Auto-confirm the download prompt with "y" for the initial confirmation
+    echo "y" | scribe-data download -wdv 20250730 || {
+        error "Failed to download Wikidata dump"
+        exit 1
+    }
+    success "Wikidata dump downloaded successfully"
+else
+    log "✅ Wikidata dump already exists: $DUMP_FILE"
+fi
+
+# MARK: Generate Language Data
+
+log "⚡ Generating language data for target languages (auto-confirm)..."
+
+# Convert arrays to space-separated strings (no quotes around the expansion)
+LANG_STRING="${TARGET_LANGUAGES[*]}"
+DATA_TYPES_STRING="${DATA_TYPES[*]}"
+
+log "Languages: $LANG_STRING"
+log "Data types: $DATA_TYPES_STRING"
+
+# Calculate total number of combinations for the responses
+NUM_LANGUAGES=${#TARGET_LANGUAGES[@]}
+NUM_DATA_TYPES=${#DATA_TYPES[@]}
+TOTAL_COMBINATIONS=$((NUM_LANGUAGES * NUM_DATA_TYPES))
+
+log "Total combinations to process: $TOTAL_COMBINATIONS"
+log "Each combination will prompt to 'Use existing latest dump'"
+log "Running: scribe-data get -l $LANG_STRING -dt $DATA_TYPES_STRING -wdp $DUMP_DIR"
+
+# Send Down Arrow twice + Enter for each combination
+# This selects the 3rd option "Use existing latest dump"
+{
+    for ((i=1; i<=TOTAL_COMBINATIONS; i++)); do
+        printf "\033[B\033[B\n"  # Down arrow, Down arrow, Enter
+    done
+} | scribe-data get -l $LANG_STRING -dt $DATA_TYPES_STRING -wdp "$DUMP_DIR"
+
 success "Language data generated successfully"
 
-# MARK: To SQLite
-
-log "🗄️  Converting to SQLite format..."
-scribe-data convert -a -ot sqlite || {
-    error "Failed to convert to SQLite format"
+# Sanity Check: Verify generated files
+log "🔍 Checking generated data in scribe_data_json_export..."
+if [ -d "scribe_data_json_export" ]; then
+    # List all generated JSON files organized by language
+    for lang in "${TARGET_LANGUAGES[@]}"; do
+        if [ -d "scribe_data_json_export/$lang" ]; then
+            log "📁 $lang:"
+            find "scribe_data_json_export/$lang" -name "*.json" | sort | while read -r file; do
+                filename=$(basename "$file")
+                log "  ✅ $filename"
+            done
+        else
+            log "⚠️  Missing directory: scribe_data_json_export/$lang"
+        fi
+    done
+    
+    # Count total files
+    total_files=$(find scribe_data_json_export -name "*.json" | wc -l)
+    expected_files=$TOTAL_COMBINATIONS
+    log "📊 Generated $total_files/$expected_files JSON files"
+    
+    if [ "$total_files" -lt "$expected_files" ]; then
+        error "⚠️  Expected $expected_files files but only found $total_files"
+        error "Some data may not have been generated successfully"
+    fi
+else
+    error "scribe_data_json_export directory not found"
     exit 1
-}
-success "Data converted to SQLite successfully"
+fi
+
+# MARK: Filter Data
+
+CONTRACTS_DIR="./scribe_data_contracts"
+log "🔍 Filtering JSON data using contracts..."
+
+if [ ! -d "$CONTRACTS_DIR" ]; then
+    warning "Contracts directory not found: $CONTRACTS_DIR"
+    warning "Skipping filtering step - proceeding with unfiltered data"
+    FILTERED_EXPORT_DIR="./scribe_data_json_export"  # Use original data
+else
+    FILTERED_EXPORT_DIR="./scribe_data_json_filtered"
+    mkdir -p "$FILTERED_EXPORT_DIR"
+
+    log "Running: scribe-data fd -cd $CONTRACTS_DIR -id scribe_data_json_export -od $FILTERED_EXPORT_DIR"
+    scribe-data fd -cd "$CONTRACTS_DIR" -id scribe_data_json_export -od "$FILTERED_EXPORT_DIR" || {
+        error "Failed to filter JSON data"
+        exit 1
+    }
+    success "JSON data filtered successfully"
+
+    # Debug: Check filtered files
+    if [ -d "$FILTERED_EXPORT_DIR" ]; then
+        filtered_files=$(find "$FILTERED_EXPORT_DIR" -name "*.json" | wc -l)
+        log "📊 Generated $filtered_files filtered JSON files"
+    fi
+
+    # MARK: Convert Filtered Data to SQLite
+
+    log "🗄️  Converting filtered data to SQLite format..."
+    scribe-data convert -if "$FILTERED_EXPORT_DIR" -lang $LANG_STRING -dt $DATA_TYPES_STRING  -ot sqlite || {
+        error "Failed to convert filtered data to SQLite format"
+        exit 1
+    }
+    success "Filtered data converted to SQLite successfully"
+fi
 
 # MARK: Check SQLite
 
@@ -184,10 +291,10 @@ if [ "$SKIP_MIGRATION" != "true" ]; then
         error "Migration failed"
         exit 1
     }
+    success "Database migration completed successfully"
 else
     log "⏭️ Skipping migration (running in CI/CD)"
 fi
-success "Database migration completed successfully"
 
 # MARK: Finish
 
@@ -202,6 +309,9 @@ log "📊 Update Summary:"
 log "  • Repository: Updated/Cloned"
 log "  • Virtual Environment: Reused or created at $VENV_DIR"
 log "  • Dependencies: Installed"
+log "  • Languages processed: ${#TARGET_LANGUAGES[@]} (${TARGET_LANGUAGES[*]})"
+log "  • Data types processed: ${#DATA_TYPES[@]}"
+log "  • Total combinations: $TOTAL_COMBINATIONS"
 log "  • Data Generation: Completed"
 log "  • SQLite Conversion: Completed"
 log "  • Files Copied: $SQLITE_FILES files"

--- a/update_data.sh
+++ b/update_data.sh
@@ -17,17 +17,8 @@ PROJECT_ROOT=$(pwd)
 
 # Define target languages and data types
 TARGET_LANGUAGES=("english" "french" "german" "italian" "spanish" "portuguese" "russian" "swedish")
+DATA_TYPES=("nouns" "verbs")
 
-# FOR TESTING PURPOSES
-# TARGET_LANGUAGES=("english" "french")
-
-
-DATA_TYPES=("adjectives" "adverbs" "conjunctions" "nouns" "personal_pronouns" "postpositions" "prepositions" "pronouns" "proper_nouns" "verbs")
-
-# FOR TESTING PURPOSES
-# DATA_TYPES=("nouns" "verbs")
-
-# Colors for output.
 RED='\033[0;31m'
 GREEN='\033[0;32m'
 YELLOW='\033[1;33m'

--- a/update_data.sh
+++ b/update_data.sh
@@ -209,7 +209,7 @@ fi
 
 # MARK: Filter Data
 
-CONTRACTS_DIR="./scribe_data_contracts"
+CONTRACTS_DIR="$PROJECT_ROOT/contracts"
 log "🔍 Filtering JSON data using contracts..."
 
 if [ ! -d "$CONTRACTS_DIR" ]; then

--- a/update_data.sh
+++ b/update_data.sh
@@ -15,7 +15,7 @@ SKIP_MIGRATION=${1:-false}
 # Save project root.
 PROJECT_ROOT=$(pwd)
 
-# Define target languages and data types
+# Define target languages and data types.
 TARGET_LANGUAGES=("english" "french" "german" "italian" "spanish" "portuguese" "russian" "swedish")
 DATA_TYPES=("nouns" "verbs")
 
@@ -137,7 +137,7 @@ DUMP_FILE="$DUMP_DIR/latest-lexemes.json.bz2"
 
 if [ ! -f "$DUMP_FILE" ]; then
     log "📥 Downloading Wikidata lexeme dump..."
-    # Auto-confirm the download prompt with "y" for the initial confirmation
+    # Auto-confirm the download prompt with "y" for the initial confirmation.
     echo "y" | scribe-data download -wdv 20250730 || {
         error "Failed to download Wikidata dump"
         exit 1
@@ -151,14 +151,14 @@ fi
 
 log "⚡ Generating language data for target languages (auto-confirm)..."
 
-# Convert arrays to space-separated strings (no quotes around the expansion)
+# Convert arrays to space-separated strings (no quotes around the expansion).
 LANG_STRING="${TARGET_LANGUAGES[*]}"
 DATA_TYPES_STRING="${DATA_TYPES[*]}"
 
 log "Languages: $LANG_STRING"
 log "Data types: $DATA_TYPES_STRING"
 
-# Calculate total number of combinations for the responses
+# Calculate total number of combinations for the responses.
 NUM_LANGUAGES=${#TARGET_LANGUAGES[@]}
 NUM_DATA_TYPES=${#DATA_TYPES[@]}
 TOTAL_COMBINATIONS=$((NUM_LANGUAGES * NUM_DATA_TYPES))
@@ -167,8 +167,8 @@ log "Total combinations to process: $TOTAL_COMBINATIONS"
 log "Each combination will prompt to 'Use existing latest dump'"
 log "Running: scribe-data get -l $LANG_STRING -dt $DATA_TYPES_STRING -wdp $DUMP_DIR"
 
-# Send Down Arrow twice + Enter for each combination
-# This selects the 3rd option "Use existing latest dump"
+# Send Down Arrow twice + Enter for each combination.
+# This selects the 3rd option "Use existing latest dump".
 {
     for ((i=1; i<=TOTAL_COMBINATIONS; i++)); do
         printf "\033[B\033[B\n"  # Down arrow, Down arrow, Enter
@@ -177,10 +177,10 @@ log "Running: scribe-data get -l $LANG_STRING -dt $DATA_TYPES_STRING -wdp $DUMP_
 
 success "Language data generated successfully"
 
-# Sanity Check: Verify generated files
+# Sanity Check: Verify generated files.
 log "🔍 Checking generated data in scribe_data_json_export..."
 if [ -d "scribe_data_json_export" ]; then
-    # List all generated JSON files organized by language
+    # List all generated JSON files organized by language.
     for lang in "${TARGET_LANGUAGES[@]}"; do
         if [ -d "scribe_data_json_export/$lang" ]; then
             log "📁 $lang:"
@@ -192,12 +192,12 @@ if [ -d "scribe_data_json_export" ]; then
             log "⚠️  Missing directory: scribe_data_json_export/$lang"
         fi
     done
-    
-    # Count total files
+
+    # Count total files.
     total_files=$(find scribe_data_json_export -name "*.json" | wc -l)
     expected_files=$TOTAL_COMBINATIONS
     log "📊 Generated $total_files/$expected_files JSON files"
-    
+
     if [ "$total_files" -lt "$expected_files" ]; then
         error "⚠️  Expected $expected_files files but only found $total_files"
         error "Some data may not have been generated successfully"
@@ -215,7 +215,7 @@ log "🔍 Filtering JSON data using contracts..."
 if [ ! -d "$CONTRACTS_DIR" ]; then
     warning "Contracts directory not found: $CONTRACTS_DIR"
     warning "Skipping filtering step - proceeding with unfiltered data"
-    FILTERED_EXPORT_DIR="./scribe_data_json_export"  # Use original data
+    FILTERED_EXPORT_DIR="./scribe_data_json_export"  # use original data
 else
     FILTERED_EXPORT_DIR="./scribe_data_json_filtered"
     mkdir -p "$FILTERED_EXPORT_DIR"
@@ -227,7 +227,7 @@ else
     }
     success "JSON data filtered successfully"
 
-    # Debug: Check filtered files
+    # Debug: Check filtered files.
     if [ -d "$FILTERED_EXPORT_DIR" ]; then
         filtered_files=$(find "$FILTERED_EXPORT_DIR" -name "*.json" | wc -l)
         log "📊 Generated $filtered_files filtered JSON files"


### PR DESCRIPTION
<!---
Thank you for your pull request! 🚀
-->

### Contributor checklist

<!-- Please replace the empty checkboxes [] below with checked ones [x] accordingly. -->

- [x] This pull request is on a [separate branch](https://docs.github.com/en/get-started/quickstart/github-flow) and not the main branch
- [x] I have ran the `./pre-commit` executable as well as `make lint` and have fixed all reported issues

---

### Description

<!--
Describe briefly what your pull request proposes to change. Especially if you have more than one commit, it is helpful to give a summary of what your contribution is trying to solve.

Also, please describe shortly how you tested that your change actually works.
-->
#### Summary

This PR makes key updates to the language data pipeline and API handlers:

1. Table naming convention
    - Changed from ENLanguageData_nouns → ENLanguageDataNounsScribe
    - Matches the naming scheme requested by @andrewtavis  for consistency across all supported languages and data types.
    
2. Data extraction improvements
    - Focused script only on converting filtered data into SQLite instead of entire dumps.
    - Pipeline steps:
        - Download lexemes dump file
        - Extract data for 8 supported languages
        - Filter data based on contracts in Scribe-Data repo
        - Convert filtered JSON -> SQLite
        - Perform DB migrations
     
    - Performance gain: Reduced extraction from ~7.55s to <400ms for English tables.
    ## 📸 Before vs After
    
    | Before | After |
    |--------|-------|
    | <img width="450" alt="After" src="https://github.com/user-attachments/assets/c7a2463e-02a6-4ec1-a5b8-b9bce009186f" /> | <img width="450" alt="Before" src="https://github.com/user-attachments/assets/881afc18-0c50-495c-9593-e87b412a2b00" />|


3. API handler fixes
    - Updated queries to use new table names & field naming conventions.
    - Ensures endpoints now fetch data correctly from the updated database schema.
    
#### Testing
To test this branch locally:

1. **Pull the THIS branch**

2. **Start MySQL**
   Open your terminal and run:

   ```bash
   mysql
   ```

3. **Update database schema**
   Run the update script in another terminal:

   ```bash
   make update
   ```

4. **Run the server**

   ```bash
   make run
   ```

5. **Test the endpoints**
   Once the server is running, you can hit the following endpoints:

   * `GET /api/v1/data/:language_iso` – Versioned API
   * `GET /api/v1/data-version/:language_iso` – Version check API
   * `GET /api/v1/languages` – List available languages


### Related issue

<!--- Scribe-Server prefers that pull requests be related to already open issues. -->
<!--- If applicable, please link to the issue by replacing ISSUE_NUMBER with the appropriate number below. -->
<!--- Feel free to delete this section if this does not apply. -->

- closes #18 as it uses the contracts provided by `Scribe-Data` to perform JSON data filtration.
