### PR TITLE
Bug/py icu

### DIFF
--- a/.github/workflows/update_scribe_data.yml
+++ b/.github/workflows/update_scribe_data.yml
@@ -60,6 +60,15 @@ jobs:
         id: run_script
         run: ./update_data.sh true
 
+      - name: Verify SQLite output
+        run: |
+          DB="./packs/sqlite/ENLanguageData.sqlite"
+          echo "Tables in $DB:"
+          sqlite3 "$DB" ".tables"
+          echo ""
+          echo "Sample row from emoji_keywords:"
+          sqlite3 "$DB" "SELECT * FROM emoji_keywords LIMIT 1;"
+
       - name: Create deployment package
         run: |
           if [ ! -d "./packs/sqlite" ]; then

--- a/.github/workflows/update_scribe_data.yml
+++ b/.github/workflows/update_scribe_data.yml
@@ -51,7 +51,7 @@ jobs:
       - name: Install system dependencies
         run: |
           sudo apt-get update
-          sudo apt-get install -y curl git sqlite3 make
+          sudo apt-get install -y curl git sqlite3 make 
 
       - name: Make script executable
         run: chmod +x ./update_data.sh

--- a/.github/workflows/update_scribe_data.yml
+++ b/.github/workflows/update_scribe_data.yml
@@ -51,7 +51,7 @@ jobs:
       - name: Install system dependencies
         run: |
           sudo apt-get update
-          sudo apt-get install -y curl git sqlite3 make
+          sudo apt-get install -y curl git sqlite3 make libicu-dev pkg-config g++ python3-dev
 
       - name: Make script executable
         run: chmod +x ./update_data.sh

--- a/.github/workflows/update_scribe_data.yml
+++ b/.github/workflows/update_scribe_data.yml
@@ -51,7 +51,7 @@ jobs:
       - name: Install system dependencies
         run: |
           sudo apt-get update
-          sudo apt-get install -y curl git sqlite3 make 
+          sudo apt-get install -y curl git sqlite3 make libicu-dev pkg-config g++ python3-dev
 
       - name: Make script executable
         run: chmod +x ./update_data.sh

--- a/.github/workflows/update_scribe_data.yml
+++ b/.github/workflows/update_scribe_data.yml
@@ -43,10 +43,10 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v4
 
-      - name: Set up Python 3.11
+      - name: Set up Python 3.12
         uses: actions/setup-python@v4
         with:
-          python-version: "3.11"
+          python-version: "3.12"
 
       - name: Install system dependencies
         run: |

--- a/.github/workflows/update_scribe_data.yml
+++ b/.github/workflows/update_scribe_data.yml
@@ -51,7 +51,7 @@ jobs:
       - name: Install system dependencies
         run: |
           sudo apt-get update
-          sudo apt-get install -y curl git sqlite3 make libicu-dev pkg-config g++ python3-dev
+          sudo apt-get install -y curl git sqlite3 make
 
       - name: Make script executable
         run: chmod +x ./update_data.sh

--- a/.github/workflows/update_scribe_data.yml
+++ b/.github/workflows/update_scribe_data.yml
@@ -62,15 +62,6 @@ jobs:
         id: run_script
         run: ./update_data.sh true
 
-      - name: Verify SQLite output
-        run: |
-          DB="./packs/sqlite/ENLanguageData.sqlite"
-          echo "Tables in $DB:"
-          sqlite3 "$DB" ".tables"
-          echo ""
-          echo "Sample row from emoji_keywords:"
-          sqlite3 "$DB" "SELECT * FROM emoji_keywords LIMIT 1;"
-
       - name: Create deployment package
         run: |
           if [ ! -d "./packs/sqlite" ]; then

--- a/update_data.sh
+++ b/update_data.sh
@@ -16,7 +16,7 @@ SKIP_MIGRATION=${1:-false}
 PROJECT_ROOT=$(pwd)
 
 # Define target languages and data types.
-TARGET_LANGUAGES=("english" "french" "german" "italian" "spanish" "portuguese" "russian" "swedish")
+TARGET_LANGUAGES=("english") #"french" "german" "italian" "spanish" "portuguese" "russian" "swedish")
 DATA_TYPES=("nouns" "verbs" "emoji_keywords")
 
 RED='\033[0;31m'

--- a/update_data.sh
+++ b/update_data.sh
@@ -16,8 +16,7 @@ SKIP_MIGRATION=${1:-false}
 PROJECT_ROOT=$(pwd)
 
 # Define target languages and data types.
-TARGET_LANGUAGES=("english") #"french" "german" "italian" "spanish" "portuguese" "russian" "swedish")
-# DATA_TYPES=("nouns" "verbs" "emoji_keywords")
+TARGET_LANGUAGES=("english" "french" "german" "italian" "spanish" "portuguese" "russian" "swedish")
 DATA_TYPES=("nouns" "verbs" "emoji_keywords")
 
 RED='\033[0;31m'
@@ -63,8 +62,7 @@ log "Log file: $LOG_FILE"
 log "📦 Setting up Scribe-Data repository..."
 if [ ! -d "$SCRIBE_DATA_DIR" ]; then
     log "Cloning Scribe-Data repository..."
-    #git clone --depth=1 https://github.com/scribe-org/Scribe-Data.git "$SCRIBE_DATA_DIR" || {
-    git clone --depth=1 --branch fix/emoji-keywords-sqlite-generation https://github.com/LJSigersmith/Scribe-Data.git "$SCRIBE_DATA_DIR" || {
+    git clone --depth=1 https://github.com/scribe-org/Scribe-Data.git "$SCRIBE_DATA_DIR" || {
         error "Failed to clone Scribe-Data repo"
         exit 1
     }

--- a/update_data.sh
+++ b/update_data.sh
@@ -131,12 +131,12 @@ pip install -e . || {
 }
 success "Dependencies installed successfully"
 
-# log "🔧 Building PyICU from source against local ICU..."
-# pip install --force-reinstall --no-binary :all: PyICU || {
-#     error "Failed to build PyICU from source"
-#     exit 1
-# }
-# success "PyICU built from source successfully"
+log "🔧 Building PyICU from source against local ICU..."
+pip install --force-reinstall --no-binary :all: PyICU || {
+    error "Failed to build PyICU from source"
+    exit 1
+}
+success "PyICU built from source successfully"
 
 # MARK: Download Wikidata Dump First
 

--- a/update_data.sh
+++ b/update_data.sh
@@ -16,8 +16,9 @@ SKIP_MIGRATION=${1:-false}
 PROJECT_ROOT=$(pwd)
 
 # Define target languages and data types.
-TARGET_LANGUAGES=("english" "french" "german" "italian" "spanish" "portuguese" "russian" "swedish")
-DATA_TYPES=("nouns" "verbs")
+TARGET_LANGUAGES=("english") #"french" "german" "italian" "spanish" "portuguese" "russian" "swedish")
+# DATA_TYPES=("nouns" "verbs" "emoji_keywords")
+DATA_TYPES=("nouns" "verbs" "emoji_keywords")
 
 RED='\033[0;31m'
 GREEN='\033[0;32m'
@@ -62,7 +63,8 @@ log "Log file: $LOG_FILE"
 log "📦 Setting up Scribe-Data repository..."
 if [ ! -d "$SCRIBE_DATA_DIR" ]; then
     log "Cloning Scribe-Data repository..."
-    git clone --depth=1 https://github.com/scribe-org/Scribe-Data.git "$SCRIBE_DATA_DIR" || {
+    #git clone --depth=1 https://github.com/scribe-org/Scribe-Data.git "$SCRIBE_DATA_DIR" || {
+    git clone --depth=1 --branch fix/emoji-keywords-sqlite-generation https://github.com/LJSigersmith/Scribe-Data.git "$SCRIBE_DATA_DIR" || {
         error "Failed to clone Scribe-Data repo"
         exit 1
     }
@@ -100,6 +102,15 @@ if ! command -v pip &> /dev/null && ! command -v pip3 &> /dev/null; then
     success "pip installed successfully"
 fi
 
+# MARK: System Dependencies
+
+log "🔧 Installing system dependencies for PyICU..."
+sudo apt-get install -y libicu-dev pkg-config g++ python3-dev || {
+    error "Failed to install system dependencies"
+    exit 1
+}
+success "System dependencies installed"
+
 # MARK: Make Venv
 
 log "🧪 Setting up virtual environment..."
@@ -129,6 +140,13 @@ pip install -e . || {
     exit 1
 }
 success "Dependencies installed successfully"
+
+log "🔧 Building PyICU from source against local ICU..."
+pip install --force-reinstall --no-binary :all: PyICU || {
+    error "Failed to build PyICU from source"
+    exit 1
+}
+success "PyICU built from source successfully"
 
 # MARK: Download Wikidata Dump First
 

--- a/update_data.sh
+++ b/update_data.sh
@@ -62,7 +62,8 @@ log "Log file: $LOG_FILE"
 log "📦 Setting up Scribe-Data repository..."
 if [ ! -d "$SCRIBE_DATA_DIR" ]; then
     log "Cloning Scribe-Data repository..."
-    git clone --depth=1 https://github.com/scribe-org/Scribe-Data.git "$SCRIBE_DATA_DIR" || {
+    #git clone --depth=1 https://github.com/scribe-org/Scribe-Data.git "$SCRIBE_DATA_DIR" || {
+    git clone --depth=1 --branch fix/emoji-keywords-sqlite-generation https://github.com/LJSigersmith/Scribe-Data.git "$SCRIBE_DATA_DIR" || {
         error "Failed to clone Scribe-Data repo"
         exit 1
     }
@@ -99,15 +100,6 @@ if ! command -v pip &> /dev/null && ! command -v pip3 &> /dev/null; then
     }
     success "pip installed successfully"
 fi
-
-# MARK: System Dependencies
-
-log "🔧 Installing system dependencies for PyICU..."
-sudo apt-get install -y libicu-dev pkg-config g++ python3-dev || {
-    error "Failed to install system dependencies"
-    exit 1
-}
-success "System dependencies installed"
 
 # MARK: Make Venv
 

--- a/update_data.sh
+++ b/update_data.sh
@@ -63,7 +63,6 @@ log "Log file: $LOG_FILE"
 log "📦 Setting up Scribe-Data repository..."
 if [ ! -d "$SCRIBE_DATA_DIR" ]; then
     log "Cloning Scribe-Data repository..."
-    #git clone --depth=1 https://github.com/scribe-org/Scribe-Data.git "$SCRIBE_DATA_DIR" || {
     git clone --depth=1 --branch fix/emoji-keywords-sqlite-generation https://github.com/LJSigersmith/Scribe-Data.git "$SCRIBE_DATA_DIR" || {
         error "Failed to clone Scribe-Data repo"
         exit 1

--- a/update_data.sh
+++ b/update_data.sh
@@ -16,7 +16,7 @@ SKIP_MIGRATION=${1:-false}
 PROJECT_ROOT=$(pwd)
 
 # Define target languages and data types.
-TARGET_LANGUAGES=("english") #"french" "german" "italian" "spanish" "portuguese" "russian" "swedish")
+TARGET_LANGUAGES=("english" "french" "german" "italian" "spanish" "portuguese" "russian" "swedish")
 DATA_TYPES=("nouns" "verbs" "emoji_keywords")
 
 RED='\033[0;31m'
@@ -62,8 +62,7 @@ log "Log file: $LOG_FILE"
 log "📦 Setting up Scribe-Data repository..."
 if [ ! -d "$SCRIBE_DATA_DIR" ]; then
     log "Cloning Scribe-Data repository..."
-    #git clone --depth=1 https://github.com/scribe-org/Scribe-Data.git "$SCRIBE_DATA_DIR" || {
-    git clone --depth=1 --branch fix/emoji-keywords-sqlite-generation https://github.com/LJSigersmith/Scribe-Data.git "$SCRIBE_DATA_DIR" || {
+    git clone --depth=1 https://github.com/scribe-org/Scribe-Data.git "$SCRIBE_DATA_DIR" || {
         error "Failed to clone Scribe-Data repo"
         exit 1
     }

--- a/update_data.sh
+++ b/update_data.sh
@@ -16,7 +16,8 @@ SKIP_MIGRATION=${1:-false}
 PROJECT_ROOT=$(pwd)
 
 # Define target languages and data types.
-TARGET_LANGUAGES=("english" "french" "german" "italian" "spanish" "portuguese" "russian" "swedish")
+TARGET_LANGUAGES=("english") #"french" "german" "italian" "spanish" "portuguese" "russian" "swedish")
+# DATA_TYPES=("nouns" "verbs" "emoji_keywords")
 DATA_TYPES=("nouns" "verbs" "emoji_keywords")
 
 RED='\033[0;31m'
@@ -62,6 +63,7 @@ log "Log file: $LOG_FILE"
 log "📦 Setting up Scribe-Data repository..."
 if [ ! -d "$SCRIBE_DATA_DIR" ]; then
     log "Cloning Scribe-Data repository..."
+    #git clone --depth=1 https://github.com/scribe-org/Scribe-Data.git "$SCRIBE_DATA_DIR" || {
     git clone --depth=1 --branch fix/emoji-keywords-sqlite-generation https://github.com/LJSigersmith/Scribe-Data.git "$SCRIBE_DATA_DIR" || {
         error "Failed to clone Scribe-Data repo"
         exit 1

--- a/update_data.sh
+++ b/update_data.sh
@@ -16,8 +16,7 @@ SKIP_MIGRATION=${1:-false}
 PROJECT_ROOT=$(pwd)
 
 # Define target languages and data types.
-TARGET_LANGUAGES=("english") #"french" "german" "italian" "spanish" "portuguese" "russian" "swedish")
-# DATA_TYPES=("nouns" "verbs" "emoji_keywords")
+TARGET_LANGUAGES=("english" "french" "german" "italian" "spanish" "portuguese" "russian" "swedish")
 DATA_TYPES=("nouns" "verbs" "emoji_keywords")
 
 RED='\033[0;31m'

--- a/update_data.sh
+++ b/update_data.sh
@@ -131,12 +131,12 @@ pip install -e . || {
 }
 success "Dependencies installed successfully"
 
-log "🔧 Building PyICU from source against local ICU..."
-pip install --force-reinstall --no-binary :all: PyICU || {
-    error "Failed to build PyICU from source"
-    exit 1
-}
-success "PyICU built from source successfully"
+# log "🔧 Building PyICU from source against local ICU..."
+# pip install --force-reinstall --no-binary :all: PyICU || {
+#     error "Failed to build PyICU from source"
+#     exit 1
+# }
+# success "PyICU built from source successfully"
 
 # MARK: Download Wikidata Dump First
 

--- a/update_data.sh
+++ b/update_data.sh
@@ -16,7 +16,7 @@ SKIP_MIGRATION=${1:-false}
 PROJECT_ROOT=$(pwd)
 
 # Define target languages and data types.
-TARGET_LANGUAGES=("english") #"french" "german" "italian" "spanish" "portuguese" "russian" "swedish")
+TARGET_LANGUAGES=("english" "french" "german" "italian" "spanish" "portuguese" "russian" "swedish")
 DATA_TYPES=("nouns" "verbs" "emoji_keywords")
 
 RED='\033[0;31m'

--- a/update_data.sh
+++ b/update_data.sh
@@ -130,9 +130,24 @@ pip install -e . || {
 }
 success "Dependencies installed successfully"
 
-log "🔧 Building PyICU from source against local ICU..."
+# MARK: PyICU
+
+# Toolforge has no pkg-config/icu-config; set ICU paths manually when needed.
+# See: https://github.com/scribe-org/Scribe-Server/blob/main/TOOLFORGE.md#install-pyicu
+# See: https://gitlab.pyicu.org/main/pyicu
+log "📦 Building PyICU from source against local ICU..."
+if ! command -v pkg-config >/dev/null 2>&1 || ! pkg-config --exists icu-i18n 2>/dev/null; then
+    log "pkg-config/icu not found — setting ICU paths for Toolforge"
+    export ICU_VERSION="${ICU_VERSION:-76}"
+    export PYICU_LFLAGS="${PYICU_LFLAGS:--L/usr/lib/x86_64-linux-gnu -licui18n -licuuc -licudata}"
+    export PYICU_CFLAGS="${PYICU_CFLAGS:--I/usr/include}"
+fi
 pip install --force-reinstall --no-binary :all: PyICU || {
     error "Failed to build PyICU from source"
+    exit 1
+}
+python3 -c "import icu" || {
+    error "PyICU installed but import failed (import icu)"
     exit 1
 }
 success "PyICU built from source successfully"


### PR DESCRIPTION
<!---
Thank you for your pull request! 🚀
-->

### Contributor checklist

<!-- Please replace the empty checkboxes [] below with checked ones [x] accordingly. -->

- [X] This pull request is on a [separate branch](https://docs.github.com/en/get-started/quickstart/github-flow) and not the main branch
- [X] I have ran the `./pre-commit` executable as well as `make lint` and have fixed all reported issues

---

### Description

<!--
Describe briefly what your pull request proposes to change. Especially if you have more than one commit, it is helpful to give a summary of what your contribution is trying to solve.

Also consider including the following:
- A description of the main files changed and what has been done in them (helps maintainers focus their review)
- A description of how you tested that your change actually works
- Pictures or a video of your change (if possible)
-->

## Fix PyICU import error and add emoji_keywords data type to update script

This PR fixes a runtime `ImportError` that caused the `update_data.sh` script to crash during emoji keyword generation, and adds `emoji_keywords` as a processed data type.

## Files Changed

**`update_data.sh`**:
- Added a `System Dependencies` section that installs `libicu-dev`, `pkg-config`, `g++`, and `python3-dev` before the virtual environment is created. Installing system deps after the venv caused a runtime import failure even when pip reported a successful install.
- Added `pip install --force-reinstall --no-binary :all: PyICU` after `pip install -e .` to ensure PyICU is always compiled from source against the locally installed ICU library rather than using a prebuilt wheel that may link against a different ICU version.
- Added `emoji_keywords` to `DATA_TYPES`, ordered after `nouns` and `verbs` as `emoji_keywords` generation requires the `scribe_data_json_export/<language>/` directory to exist, which is created when nouns are processed first.

**`.github/workflows/update_scribe_data.yml`**:
- Updated Python version from 3.11 to 3.12, as Scribe-Data requires `>=3.12`.
- Added a "Verify SQLite output" step that prints the tables and a sample `emoji_keywords` row after the script runs to confirm the output is valid before packaging.

## Testing

Tested locally on a Raspberry Pi 4 running Ubuntu using a fork of Scribe-Data ([LJSigersmith/Scribe-Data, branch `fix/emoji-keywords-sqlite-generation`](https://github.com/LJSigersmith/Scribe-Data/tree/fix/emoji-keywords-sqlite-generation)) which includes fixes to emoji keyword SQLite generation. The full script ran successfully, generating and migrating `emoji_keywords` for English, with 3,393 emoji keywords written to the database. Also validated via GitHub Actions on the fork. The CI run confirmed the SQLite output step printed correct tables and a sample row.

> **Note:** This PR depends on fixes in Scribe-Data being merged upstream. 


### Related issue

<!--- Scribe-Server prefers that pull requests be related to already open issues. -->
<!--- If applicable, please link to the issue by replacing ISSUE_NUMBER with the appropriate number below. -->
<!--- You can also put "Closes" before the # to close the issue on merge, or say there is no related issue. -->

- Closes #43 
