### PR TITLE
Implement translation data retrieval endpoint and validation logic

### DIFF
--- a/api/dbqueries/translation_queries.go
+++ b/api/dbqueries/translation_queries.go
@@ -1,0 +1,67 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+package dbqueries
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/scribe-org/scribe-server/database"
+	"github.com/scribe-org/scribe-server/models"
+)
+
+// GetTranslationTableData fetches translation data for the given target and source language codes.
+// It queries the TranslationData{TARGET}From{SOURCE} table and returns data nested as:
+// word -> wordType -> wordOrder -> TranslationEntry.
+func GetTranslationTableData(targetLang, sourceLang string) (map[string]map[string]map[string]models.TranslationEntry, error) {
+	tableName := fmt.Sprintf("TranslationData%sFrom%s",
+		strings.ToUpper(targetLang),
+		strings.ToUpper(sourceLang),
+	)
+
+	if !database.IsValidTranslationTableName(tableName) {
+		return nil, fmt.Errorf("invalid translation table name: %s", tableName)
+	}
+
+	exists, err := database.TableExists(tableName)
+	if err != nil {
+		return nil, fmt.Errorf("error checking table existence for %s: %w", tableName, err)
+	}
+	if !exists {
+		return nil, fmt.Errorf("translation table %s does not exist", tableName)
+	}
+
+	rows, err := database.DB.Query(
+		fmt.Sprintf("SELECT word, wordType, wordOrder, description, translation FROM `%s`", tableName),
+	)
+	if err != nil {
+		return nil, fmt.Errorf("error querying %s: %w", tableName, err)
+	}
+	defer rows.Close()
+
+	result := make(map[string]map[string]map[string]models.TranslationEntry)
+
+	for rows.Next() {
+		var word, wordType, wordOrder, description, translation string
+		if err := rows.Scan(&word, &wordType, &wordOrder, &description, &translation); err != nil {
+			return nil, fmt.Errorf("error scanning row: %w", err)
+		}
+
+		if result[word] == nil {
+			result[word] = make(map[string]map[string]models.TranslationEntry)
+		}
+		if result[word][wordType] == nil {
+			result[word][wordType] = make(map[string]models.TranslationEntry)
+		}
+		result[word][wordType][wordOrder] = models.TranslationEntry{
+			Description: description,
+			Translation: translation,
+		}
+	}
+
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("error iterating rows: %w", err)
+	}
+
+	return result, nil
+}

--- a/api/handlers/language.go
+++ b/api/handlers/language.go
@@ -274,8 +274,13 @@ func GetContracts(c *gin.Context) {
 // @Failure 500 {object} models.ErrorResponse "Internal server error"
 // @Router /api/v1/translations/{targetLang}/{sourceLang} [get]
 func GetTranslationData(c *gin.Context) {
-	targetLang := c.Param("targetLang")
-	sourceLang := c.Param("sourceLang")
+	sourceLang := c.Query("source_lang")
+	targetLang := c.Query("target_lang")
+
+	if sourceLang == "" || targetLang == "" {
+		HandleError(c, http.StatusBadRequest, constants.EmptyTranslationCodeError)
+		return
+	}
 
 	if !validators.IsValidTranslationLangCode(targetLang) || !validators.IsValidTranslationLangCode(sourceLang) {
 		HandleError(c, http.StatusBadRequest, constants.InvalidTranslationLangCodeError)

--- a/api/handlers/language.go
+++ b/api/handlers/language.go
@@ -257,6 +257,49 @@ func GetContracts(c *gin.Context) {
 	})
 }
 
+// MARK: Translation Data Retrieval
+
+// GetTranslationData returns translation data from a source language into a target language.
+//
+// @Summary Retrieve translation data
+// @Description Returns nested translation data for the given target and source language ISO codes.
+// @Tags Translations
+// @Accept  json
+// @Produce  json
+// @Param targetLang path string true "Target language code (ISO 639-1)" example(bn)
+// @Param sourceLang path string true "Source language code (ISO 639-1)" example(de)
+// @Success 200 {object} models.TranslationDataResponse "Successfully retrieved translation data"
+// @Failure 400 {object} models.ErrorResponse "Invalid language code"
+// @Failure 404 {object} models.ErrorResponse "Translation data not found"
+// @Failure 500 {object} models.ErrorResponse "Internal server error"
+// @Router /api/v1/translations/{targetLang}/{sourceLang} [get]
+func GetTranslationData(c *gin.Context) {
+	targetLang := c.Param("targetLang")
+	sourceLang := c.Param("sourceLang")
+
+	if !validators.IsValidTranslationLangCode(targetLang) || !validators.IsValidTranslationLangCode(sourceLang) {
+		HandleError(c, http.StatusBadRequest, constants.InvalidTranslationLangCodeError)
+		return
+	}
+
+	data, err := dbqueries.GetTranslationTableData(targetLang, sourceLang)
+	if err != nil {
+		log.Printf("Error fetching translation data for %s/%s: %v", targetLang, sourceLang, err)
+		if strings.Contains(err.Error(), "does not exist") {
+			HandleError(c, http.StatusNotFound, fmt.Sprintf("No translation data for '%s' from '%s'", targetLang, sourceLang))
+			return
+		}
+		HandleError(c, http.StatusInternalServerError, constants.ErrorFetchingTranslationData)
+		return
+	}
+
+	HandleSuccess(c, models.TranslationDataResponse{
+		TargetLang: targetLang,
+		SourceLang: sourceLang,
+		Data:       data,
+	})
+}
+
 // MARK: Contract Loading Helpers
 
 // loadSingleContract reads and unmarshals a single contract file.

--- a/api/handlers/language.go
+++ b/api/handlers/language.go
@@ -266,13 +266,13 @@ func GetContracts(c *gin.Context) {
 // @Tags Translations
 // @Accept  json
 // @Produce  json
-// @Param targetLang path string true "Target language code (ISO 639-1)" example(bn)
-// @Param sourceLang path string true "Source language code (ISO 639-1)" example(de)
+// @Param source_lang path string true "Source language code (ISO 639-1)" example(de)
+// @Param target_lang path string true "Target language code (ISO 639-1)" example(bn)
 // @Success 200 {object} models.TranslationDataResponse "Successfully retrieved translation data"
 // @Failure 400 {object} models.ErrorResponse "Invalid language code"
 // @Failure 404 {object} models.ErrorResponse "Translation data not found"
 // @Failure 500 {object} models.ErrorResponse "Internal server error"
-// @Router /api/v1/translations/{targetLang}/{sourceLang} [get]
+// @Router /api/v1/translations [get]
 func GetTranslationData(c *gin.Context) {
 	sourceLang := c.Query("source_lang")
 	targetLang := c.Query("target_lang")

--- a/api/routes.go
+++ b/api/routes.go
@@ -21,7 +21,7 @@ func SetupRoutes(r *gin.Engine) {
 			v1.GET("/languages", handlers.GetAvailableLanguages)
 			v1.GET("/contracts", handlers.GetContracts)
 			v1.GET("/language-stats", handlers.GetLanguageStats)
-			v1.GET("/translations/:targetLang/:sourceLang", handlers.GetTranslationData)
+			v1.GET("/translations", handlers.GetTranslationData)
 		}
 	}
 }

--- a/api/routes.go
+++ b/api/routes.go
@@ -21,6 +21,7 @@ func SetupRoutes(r *gin.Engine) {
 			v1.GET("/languages", handlers.GetAvailableLanguages)
 			v1.GET("/contracts", handlers.GetContracts)
 			v1.GET("/language-stats", handlers.GetLanguageStats)
+			v1.GET("/translations/:targetLang/:sourceLang", handlers.GetTranslationData)
 		}
 	}
 }

--- a/api/server.go
+++ b/api/server.go
@@ -197,6 +197,7 @@ func startServer(r *gin.Engine) {
 	log.Println("  ✅ GET /api/v1/data/:lang_iso       		- Get full language data with schema")
 	log.Println("  ✅ GET /api/v1/data-version/:lang_iso 		- Get version info for a language")
 	log.Println("  ✅ GET /api/v1/language-stats?codes=fr,de         - Get statistics for all or selected languages")
+	log.Println("  ✅ GET /api/v1/translations/:source/:target 		- Get translation data of target from source ")
 	log.Printf("📊 Available languages: %v", availableLanguages)
 
 	log.Fatal(r.Run(hostPort))

--- a/api/server.go
+++ b/api/server.go
@@ -192,12 +192,12 @@ func startServer(r *gin.Engine) {
 
 	log.Printf("👀 Listening on port %s", hostPort)
 	log.Println("🚀 API Endpoints:")
-	log.Println("  ✅ GET /api/v1/languages                		- List available languages")
-	log.Println("  ✅ GET /api/v1/contracts[?lang_iso=xx]      	- Get contracts (optional language filter)")
-	log.Println("  ✅ GET /api/v1/data/:lang_iso       		- Get full language data with schema")
-	log.Println("  ✅ GET /api/v1/data-version/:lang_iso 		- Get version info for a language")
-	log.Println("  ✅ GET /api/v1/language-stats?codes=fr,de         - Get statistics for all or selected languages")
-	log.Println("  ✅ GET /api/v1/translations/:source/:target 		- Get translation data of target from source ")
+	log.Println("  ✅ GET /api/v1/languages                				- List available languages")
+	log.Println("  ✅ GET /api/v1/contracts[?lang_iso=xx]      			- Get contracts (optional language filter)")
+	log.Println("  ✅ GET /api/v1/data/:lang_iso       				- Get full language data with schema")
+	log.Println("  ✅ GET /api/v1/data-version/:lang_iso 				- Get version info for a language")
+	log.Println("  ✅ GET /api/v1/language-stats?codes=fr,de         		- Get statistics for all or selected languages")
+	log.Println("  ✅ GET /api/v1/translations?source_lang=es&target_lang=en  	- Get translation data of target from source")
 	log.Printf("📊 Available languages: %v", availableLanguages)
 
 	log.Fatal(r.Run(hostPort))

--- a/api/validators/language_validator.go
+++ b/api/validators/language_validator.go
@@ -4,6 +4,7 @@
 package validators
 
 import (
+	"regexp"
 	"slices"
 	"strings"
 	"sync"
@@ -51,4 +52,11 @@ func SanitizeLanguageCode(lang string) string {
 // IsLanguageSupported checks if a language exists in the provided list.
 func IsLanguageSupported(lang string, availableLanguages []string) bool {
 	return slices.Contains(availableLanguages, lang)
+}
+
+// IsValidTranslationLangCode checks if a language code is valid for translation endpoints.
+// Accepts 2–4 lowercase ASCII letters (e.g. "bn", "de", "dag", "pnb").
+func IsValidTranslationLangCode(lang string) bool {
+	matched, err := regexp.MatchString(`^[a-z]{2,4}$`, lang)
+	return err == nil && matched
 }

--- a/cmd/migrate/mariadb/queries.go
+++ b/cmd/migrate/mariadb/queries.go
@@ -34,21 +34,25 @@ func generateMariaTableName(langCode, tableName string) string {
 	// Remove sqlite_ prefix if present.
 	cleanTableName := strings.TrimPrefix(tableName, "sqlite_")
 
-	// Clean up table name - replace underscores and capitalize properly.
-	cleanTableName = strings.ReplaceAll(cleanTableName, "_", "")
-
-	caser := cases.Title(language.English)
-	cleanTableName = caser.String(cleanTableName)
-
 	// Special handling for TranslationData tables.
-	if strings.HasPrefix(langCode, "TranslationData") {
-		// For TranslationData, just use TranslationData + Language:
-		// TranslationData + english -> TranslationDataEnglish
-		return "TranslationData" + cleanTableName
+	// Table names follow the pattern: {target}_translations_from_{source}
+	// e.g. bn_translations_from_de -> TranslationDataBNFromDE
+	if langCode == "TranslationData" {
+		parts := strings.Split(cleanTableName, "_")
+		if len(parts) == 4 && parts[1] == "translations" && parts[2] == "from" {
+			target := strings.ToUpper(parts[0])
+			source := strings.ToUpper(parts[3])
+			return "TranslationData" + target + "From" + source
+		}
+		// Fallback: strip underscores and title-case.
+		caser := cases.Title(language.English)
+		return "TranslationData" + caser.String(strings.ReplaceAll(cleanTableName, "_", ""))
 	}
 
 	// For language data tables, capitalize table name and add Scribe suffix:
 	// ENLanguageData + nouns -> ENLanguageDataNounsScribe
+	caser := cases.Title(language.English)
+	cleanTableName = caser.String(strings.ReplaceAll(cleanTableName, "_", ""))
 	return langCode + cleanTableName + "Scribe"
 }
 

--- a/database/utils.go
+++ b/database/utils.go
@@ -36,6 +36,28 @@ func IsValidTableName(tableName string) bool {
 	return matched
 }
 
+// IsValidTranslationTableName validates TranslationData table names.
+// Pattern: TranslationData{TARGET}From{SOURCE} e.g. TranslationDataBNFromDE.
+func IsValidTranslationTableName(tableName string) bool {
+	pattern := `^TranslationData[A-Z]{2,4}From[A-Z]{2,4}$`
+	matched, err := regexp.MatchString(pattern, tableName)
+	if err != nil || !matched {
+		return false
+	}
+
+	if len(tableName) > 60 || len(tableName) < 23 {
+		return false
+	}
+
+	for _, char := range tableName {
+		if !constants.IsAlphaNumeric(char) {
+			return false
+		}
+	}
+
+	return true
+}
+
 // MARK: Pointer Conversion
 
 // ToIntPtr converts various numeric types to a pointer to int.

--- a/docs/docs.go
+++ b/docs/docs.go
@@ -257,7 +257,7 @@ const docTemplate = `{
                 }
             }
         },
-        "/api/v1/translations/{targetLang}/{sourceLang}": {
+        "/api/v1/translations": {
             "get": {
                 "description": "Returns nested translation data for the given target and source language ISO codes.",
                 "consumes": [
@@ -273,17 +273,17 @@ const docTemplate = `{
                 "parameters": [
                     {
                         "type": "string",
-                        "example": "bn",
-                        "description": "Target language code (ISO 639-1)",
-                        "name": "targetLang",
+                        "example": "de",
+                        "description": "Source language code (ISO 639-1)",
+                        "name": "source_lang",
                         "in": "path",
                         "required": true
                     },
                     {
                         "type": "string",
-                        "example": "de",
-                        "description": "Source language code (ISO 639-1)",
-                        "name": "sourceLang",
+                        "example": "bn",
+                        "description": "Target language code (ISO 639-1)",
+                        "name": "target_lang",
                         "in": "path",
                         "required": true
                     }

--- a/docs/docs.go
+++ b/docs/docs.go
@@ -256,6 +256,65 @@ const docTemplate = `{
                     }
                 }
             }
+        },
+        "/api/v1/translations/{targetLang}/{sourceLang}": {
+            "get": {
+                "description": "Returns nested translation data for the given target and source language ISO codes.",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "Translations"
+                ],
+                "summary": "Retrieve translation data",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "example": "bn",
+                        "description": "Target language code (ISO 639-1)",
+                        "name": "targetLang",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "example": "de",
+                        "description": "Source language code (ISO 639-1)",
+                        "name": "sourceLang",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Successfully retrieved translation data",
+                        "schema": {
+                            "$ref": "#/definitions/models.TranslationDataResponse"
+                        }
+                    },
+                    "400": {
+                        "description": "Invalid language code",
+                        "schema": {
+                            "$ref": "#/definitions/models.ErrorResponse"
+                        }
+                    },
+                    "404": {
+                        "description": "Translation data not found",
+                        "schema": {
+                            "$ref": "#/definitions/models.ErrorResponse"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal server error",
+                        "schema": {
+                            "$ref": "#/definitions/models.ErrorResponse"
+                        }
+                    }
+                }
+            }
         }
     },
     "definitions": {
@@ -383,6 +442,45 @@ const docTemplate = `{
                     "additionalProperties": {
                         "type": "string"
                     }
+                }
+            }
+        },
+        "models.TranslationDataResponse": {
+            "type": "object",
+            "properties": {
+                "data": {
+                    "description": "Nested translation data",
+                    "type": "object",
+                    "additionalProperties": {
+                        "type": "object",
+                        "additionalProperties": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "$ref": "#/definitions/models.TranslationEntry"
+                            }
+                        }
+                    }
+                },
+                "source_lang": {
+                    "description": "ISO code of the source language (e.g. \"de\")",
+                    "type": "string"
+                },
+                "target_lang": {
+                    "description": "ISO code of the target language (e.g. \"bn\")",
+                    "type": "string"
+                }
+            }
+        },
+        "models.TranslationEntry": {
+            "type": "object",
+            "properties": {
+                "description": {
+                    "description": "Description of the word in the source language",
+                    "type": "string"
+                },
+                "translation": {
+                    "description": "Translation of the word in the target language",
+                    "type": "string"
                 }
             }
         }

--- a/docs/swagger.json
+++ b/docs/swagger.json
@@ -251,7 +251,7 @@
                 }
             }
         },
-        "/api/v1/translations/{targetLang}/{sourceLang}": {
+        "/api/v1/translations": {
             "get": {
                 "description": "Returns nested translation data for the given target and source language ISO codes.",
                 "consumes": [
@@ -267,17 +267,17 @@
                 "parameters": [
                     {
                         "type": "string",
-                        "example": "bn",
-                        "description": "Target language code (ISO 639-1)",
-                        "name": "targetLang",
+                        "example": "de",
+                        "description": "Source language code (ISO 639-1)",
+                        "name": "source_lang",
                         "in": "path",
                         "required": true
                     },
                     {
                         "type": "string",
-                        "example": "de",
-                        "description": "Source language code (ISO 639-1)",
-                        "name": "sourceLang",
+                        "example": "bn",
+                        "description": "Target language code (ISO 639-1)",
+                        "name": "target_lang",
                         "in": "path",
                         "required": true
                     }

--- a/docs/swagger.json
+++ b/docs/swagger.json
@@ -250,6 +250,65 @@
                     }
                 }
             }
+        },
+        "/api/v1/translations/{targetLang}/{sourceLang}": {
+            "get": {
+                "description": "Returns nested translation data for the given target and source language ISO codes.",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "Translations"
+                ],
+                "summary": "Retrieve translation data",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "example": "bn",
+                        "description": "Target language code (ISO 639-1)",
+                        "name": "targetLang",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "example": "de",
+                        "description": "Source language code (ISO 639-1)",
+                        "name": "sourceLang",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Successfully retrieved translation data",
+                        "schema": {
+                            "$ref": "#/definitions/models.TranslationDataResponse"
+                        }
+                    },
+                    "400": {
+                        "description": "Invalid language code",
+                        "schema": {
+                            "$ref": "#/definitions/models.ErrorResponse"
+                        }
+                    },
+                    "404": {
+                        "description": "Translation data not found",
+                        "schema": {
+                            "$ref": "#/definitions/models.ErrorResponse"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal server error",
+                        "schema": {
+                            "$ref": "#/definitions/models.ErrorResponse"
+                        }
+                    }
+                }
+            }
         }
     },
     "definitions": {
@@ -377,6 +436,45 @@
                     "additionalProperties": {
                         "type": "string"
                     }
+                }
+            }
+        },
+        "models.TranslationDataResponse": {
+            "type": "object",
+            "properties": {
+                "data": {
+                    "description": "Nested translation data",
+                    "type": "object",
+                    "additionalProperties": {
+                        "type": "object",
+                        "additionalProperties": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "$ref": "#/definitions/models.TranslationEntry"
+                            }
+                        }
+                    }
+                },
+                "source_lang": {
+                    "description": "ISO code of the source language (e.g. \"de\")",
+                    "type": "string"
+                },
+                "target_lang": {
+                    "description": "ISO code of the target language (e.g. \"bn\")",
+                    "type": "string"
+                }
+            }
+        },
+        "models.TranslationEntry": {
+            "type": "object",
+            "properties": {
+                "description": {
+                    "description": "Description of the word in the source language",
+                    "type": "string"
+                },
+                "translation": {
+                    "description": "Translation of the word in the target language",
+                    "type": "string"
                 }
             }
         }

--- a/docs/swagger.yaml
+++ b/docs/swagger.yaml
@@ -86,6 +86,33 @@ definitions:
         description: Map of data types to version identifiers
         type: object
     type: object
+  models.TranslationDataResponse:
+    properties:
+      data:
+        additionalProperties:
+          additionalProperties:
+            additionalProperties:
+              $ref: '#/definitions/models.TranslationEntry'
+            type: object
+          type: object
+        description: Nested translation data
+        type: object
+      source_lang:
+        description: ISO code of the source language (e.g. "de")
+        type: string
+      target_lang:
+        description: ISO code of the target language (e.g. "bn")
+        type: string
+    type: object
+  models.TranslationEntry:
+    properties:
+      description:
+        description: Description of the word in the source language
+        type: string
+      translation:
+        description: Translation of the word in the target language
+        type: string
+    type: object
 externalDocs:
   description: GitHub Repository
   url: https://github.com/scribe-org/Scribe-Server
@@ -263,4 +290,45 @@ paths:
       summary: List all supported languages
       tags:
       - Languages
+  /api/v1/translations/{targetLang}/{sourceLang}:
+    get:
+      consumes:
+      - application/json
+      description: Returns nested translation data for the given target and source
+        language ISO codes.
+      parameters:
+      - description: Target language code (ISO 639-1)
+        example: bn
+        in: path
+        name: targetLang
+        required: true
+        type: string
+      - description: Source language code (ISO 639-1)
+        example: de
+        in: path
+        name: sourceLang
+        required: true
+        type: string
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: Successfully retrieved translation data
+          schema:
+            $ref: '#/definitions/models.TranslationDataResponse'
+        "400":
+          description: Invalid language code
+          schema:
+            $ref: '#/definitions/models.ErrorResponse'
+        "404":
+          description: Translation data not found
+          schema:
+            $ref: '#/definitions/models.ErrorResponse'
+        "500":
+          description: Internal server error
+          schema:
+            $ref: '#/definitions/models.ErrorResponse'
+      summary: Retrieve translation data
+      tags:
+      - Translations
 swagger: "2.0"

--- a/docs/swagger.yaml
+++ b/docs/swagger.yaml
@@ -290,23 +290,23 @@ paths:
       summary: List all supported languages
       tags:
       - Languages
-  /api/v1/translations/{targetLang}/{sourceLang}:
+  /api/v1/translations:
     get:
       consumes:
       - application/json
       description: Returns nested translation data for the given target and source
         language ISO codes.
       parameters:
-      - description: Target language code (ISO 639-1)
-        example: bn
-        in: path
-        name: targetLang
-        required: true
-        type: string
       - description: Source language code (ISO 639-1)
         example: de
         in: path
-        name: sourceLang
+        name: source_lang
+        required: true
+        type: string
+      - description: Target language code (ISO 639-1)
+        example: bn
+        in: path
+        name: target_lang
         required: true
         type: string
       produces:

--- a/internal/constants/errors.go
+++ b/internal/constants/errors.go
@@ -12,4 +12,10 @@ const (
 
 	// ErrorFetchingLanguageVersions indicates a failure when retrieving language version data.
 	ErrorFetchingLanguageVersions = "Failed to fetch language versions"
+
+	// InvalidTranslationLangCodeError indicates a translation language code is invalid.
+	InvalidTranslationLangCodeError = "Invalid language code. Use 2–4 lowercase letters (e.g. 'bn', 'de', 'dag')"
+
+	// ErrorFetchingTranslationData indicates a failure when retrieving translation data.
+	ErrorFetchingTranslationData = "Failed to fetch translation data"
 )

--- a/internal/constants/errors.go
+++ b/internal/constants/errors.go
@@ -14,7 +14,7 @@ const (
 	ErrorFetchingLanguageVersions = "Failed to fetch language versions"
 
 	// InvalidTranslationLangCodeError indicates a translation language code is invalid.
-	InvalidTranslationLangCodeError = "Invalid language code. Use 2–4 lowercase letters (e.g. 'bn', 'de', 'dag')"
+	InvalidTranslationLangCodeError = "Invalid language code. Use 2-4 lowercase letters (e.g. 'bn', 'de', 'dag')"
 
 	// ErrorFetchingTranslationData indicates a failure when retrieving translation data.
 	ErrorFetchingTranslationData = "Failed to fetch translation data"

--- a/internal/constants/errors.go
+++ b/internal/constants/errors.go
@@ -18,4 +18,7 @@ const (
 
 	// ErrorFetchingTranslationData indicates a failure when retrieving translation data.
 	ErrorFetchingTranslationData = "Failed to fetch translation data"
+
+	// EmptyTranslationCodeError indicates a failure when language code is not passed.
+	EmptyTranslationCodeError = "Empty translation code detected. Ensure you pass in valid source and target language code"
 )

--- a/models/models.go
+++ b/models/models.go
@@ -80,6 +80,29 @@ type AvailableLanguagesResponse struct {
 	Languages []LanguageInfo `json:"languages"`
 }
 
+// MARK: Translation Models
+
+// TranslationEntry holds the description and translation for a single word order entry.
+// swagger:model TranslationEntry
+type TranslationEntry struct {
+	// Description of the word in the source language
+	Description string `json:"description"`
+	// Translation of the word in the target language
+	Translation string `json:"translation"`
+}
+
+// TranslationDataResponse represents translation data from a source language into a target language.
+// Data is nested as: word -> wordType -> wordOrder -> TranslationEntry.
+// swagger:model TranslationDataResponse
+type TranslationDataResponse struct {
+	// ISO code of the target language (e.g. "bn")
+	TargetLang string `json:"target_lang"`
+	// ISO code of the source language (e.g. "de")
+	SourceLang string `json:"source_lang"`
+	// Nested translation data
+	Data map[string]map[string]map[string]TranslationEntry `json:"data"`
+}
+
 // MARK: Statistics Models
 
 // LanguageStatisticsReponse represents linguistic statistics for a language.

--- a/static/index.html
+++ b/static/index.html
@@ -334,6 +334,9 @@
               GET /api/v1/language-stats?codes=fr,de - Get statistics for all or
               selected languages
             </li>
+            <li>
+              GET /api/v1/ltranslations/:source/:target - Get translation data of target from source
+            </li>
           </ul>
         </div>
       </div>

--- a/static/index.html
+++ b/static/index.html
@@ -319,23 +319,15 @@
         <div class="endpoints-list">
           <ul>
             <li>GET /api/v1/languages - List available languages</li>
-            <li>
-              GET /api/v1/contracts[?lang_iso=xx] - Get contracts (optional
-              language filter)
+            <li>GET /api/v1/contracts[?lang_iso=xx] - Get contracts (optional language filter)
             </li>
-            <li>
-              GET /api/v1/data/:lang_iso - Get full language data with schema
+            <li>GET /api/v1/data/:lang_iso - Get full language data with schema
             </li>
-            <li>
-              GET /api/v1/data-version/:lang_iso - Get version info for a
-              language
+            <li>GET /api/v1/data-version/:lang_iso - Get version info for a language
             </li>
-            <li>
-              GET /api/v1/language-stats?codes=fr,de - Get statistics for all or
-              selected languages
+            <li>GET /api/v1/language-stats?codes=fr,de - Get statistics for all or selected languages
             </li>
-            <li>
-              GET /api/v1/ltranslations/:source/:target - Get translation data of target from source
+            <li>GET /api/v1/translations?source_lang=es&target_lang=en - Get translation data of target from source
             </li>
           </ul>
         </div>


### PR DESCRIPTION
<!---
Thank you for your pull request! 🚀
-->

### Contributor checklist

<!-- Please replace the empty checkboxes [] below with checked ones [x] accordingly. -->

- [X] This pull request is on a [separate branch](https://docs.github.com/en/get-started/quickstart/github-flow) and not the main branch
- [X] I have ran the `./pre-commit` executable as well as `make lint` and have fixed all reported issues

---

### Description


- Added a new endpoint to retrieve translation data between source and target languages.
- Implemented validation for language codes used in translation requests.
- Introduced models for translation data response and updated error handling for invalid requests.
- Enhanced table name validation for translation data in the database.

<!--
Describe briefly what your pull request proposes to change. Especially if you have more than one commit, it is helpful to give a summary of what your contribution is trying to solve.

Also consider including the following:
- A description of the main files changed and what has been done in them (helps maintainers focus their review)
- A description of how you tested that your change actually works
- Pictures or a video of your change (if possible)

Route -
```
GET /api/v1/translations/:targetLang/:sourceLang
```
Example call:
```
GET /api/v1/translations/bn/de
```
-->

<img width="978" height="934" alt="image" src="https://github.com/user-attachments/assets/a426fa39-4b12-4524-b0e3-bb315fa962e1" />

In local MariaDB:

<img width="865" height="538" alt="image" src="https://github.com/user-attachments/assets/3735b5d4-1744-41ad-8e35-28f94d76bbdc" />



### Related issue

<!--- Scribe-Server prefers that pull requests be related to already open issues. -->
<!--- If applicable, please link to the issue by replacing ISSUE_NUMBER with the appropriate number below. -->
<!--- You can also put "Closes" before the # to close the issue on merge, or say there is no related issue. -->



- Closes #59 
- Closes #58 
