### PR TITLE
fix: update download command in update_data.sh

### DIFF
--- a/update_data.sh
+++ b/update_data.sh
@@ -160,7 +160,7 @@ DUMP_FILE="$DUMP_DIR/latest-lexemes.json.bz2"
 if [ ! -f "$DUMP_FILE" ]; then
     log "📥 Downloading Wikidata lexeme dump..."
     # Auto-confirm the download prompt with "y" for the initial confirmation.
-    echo "y" | scribe-data download -wdv latest || {
+    echo "y" | scribe-data download -wdp "$DUMP_DIR" --dump-snapshot latest-lexemes || {
         error "Failed to download Wikidata dump"
         exit 1
     }


### PR DESCRIPTION
<!---
Thank you for your pull request! 🚀
-->

### Contributor checklist

<!-- Please replace the empty checkboxes [] below with checked ones [x] accordingly. -->

- [X] This pull request is on a [separate branch](https://docs.github.com/en/get-started/quickstart/github-flow) and not the main branch
- [X] I have ran the `./pre-commit` executable as well as `make lint` and have fixed all reported issues

---

### Description

- Fix Wikidata dump download in `update_data.sh`: old `-wdv latest` no longer valid in current `scribe-data` CLI

<!--
Describe briefly what your pull request proposes to change. Especially if you have more than one commit, it is helpful to give a summary of what your contribution is trying to solve.

Also consider including the following:
- A description of the main files changed and what has been done in them (helps maintainers focus their review)
- A description of how you tested that your change actually works
- Pictures or a video of your change (if possible)
-->
 
<!--- Scribe-Server prefers that pull requests be related to already open issues. -->
<!--- If applicable, please link to the issue by replacing ISSUE_NUMBER with the appropriate number below. -->
<!--- You can also put "Closes" before the # to close the issue on merge, or say there is no related issue. -->
 