### PR TITLE
fix static asset paths to load from project root

### DIFF
--- a/api/server.go
+++ b/api/server.go
@@ -168,12 +168,12 @@ func setupStaticFiles(r *gin.Engine) {
 		http.StripPrefix("/packs/", fs).ServeHTTP(c.Writer, c.Request)
 	})
 
-	faviconPath := filepath.Join(absPath, "..", "static", "favicon.ico")
+	faviconPath := filepath.Join("static", "favicon.ico")
 	if _, err := os.Stat(faviconPath); err == nil {
 		r.StaticFile("/favicon.ico", faviconPath)
 	}
 
-	logoPath := filepath.Join(absPath, "static", "images", "ScribeServerLogoWhite.png")
+	logoPath := filepath.Join("static", "images", "ScribeServerLogoWhite.png")
 	if _, err := os.Stat(logoPath); err == nil {
 		r.StaticFile("/images/ScribeServerLogoWhite.png", logoPath)
 	}


### PR DESCRIPTION
<!---
Thank you for your pull request! 🚀
-->

### Contributor checklist

<!-- Please replace the empty checkboxes [] below with checked ones [x] accordingly. -->

- [x] This pull request is on a [separate branch](https://docs.github.com/en/get-started/quickstart/github-flow) and not the main branch
- [x] I have ran the `./pre-commit` executable as well as `make lint` and have fixed all reported issues

---

### Description

Fixes the broken logo images caused by differing local configurations.

**Root cause:**
The web images were tied to the `fileSystem` variable (which dictates where data packs live). If a user's `fileSystem` wasn't set to the exact project root, the image paths broke.

I just made sure we don't depend on contributors' local config setup. This was why one configuration was working for one computer and not working on another.

Reference: https://github.com/scribe-org/Scribe-Server/pull/72#discussion_r3644517400


<!--
Describe briefly what your pull request proposes to change. Especially if you have more than one commit, it is helpful to give a summary of what your contribution is trying to solve.

Also consider including the following:
- A description of the main files changed and what has been done in them (helps maintainers focus their review)
- A description of how you tested that your change actually works
- Pictures or a video of your change (if possible)
-->
