### PR TITLE
Add Testing guide and principles

### DIFF
--- a/.github/workflows/pr_ci.yaml
+++ b/.github/workflows/pr_ci.yaml
@@ -14,6 +14,16 @@ on:
       - "Makefile"
       - "TESTING.md"
       - ".github/workflows/pr_ci.yaml"
+  push:
+    branches:
+      - main
+    paths:
+      - "**/*.go"
+      - "go.mod"
+      - "go.sum"
+      - "Makefile"
+      - "TESTING.md"
+      - ".github/workflows/pr_ci.yaml"
 
 permissions:
   contents: read

--- a/.github/workflows/pr_ci.yaml
+++ b/.github/workflows/pr_ci.yaml
@@ -9,6 +9,11 @@ on:
       - synchronize
     paths:
       - "**/*.go"
+      - "go.mod"
+      - "go.sum"
+      - "Makefile"
+      - "TESTING.md"
+      - ".github/workflows/pr_ci.yaml"
 
 permissions:
   contents: read
@@ -25,7 +30,7 @@ jobs:
           go-version-file: "go.mod"
 
       - name: Install dependencies
-        run: go get .
+        run: go mod download
 
       - name: Lint with golangci-lint
         uses: golangci/golangci-lint-action@v9
@@ -34,6 +39,4 @@ jobs:
           only-new-issues: true
 
       - name: Run tests and show coverage
-        run: |
-          go test ./... -coverprofile=coverage.out
-          go tool cover -func=coverage.out
+        run: make test-cover

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -16,6 +16,7 @@ If you have questions or would like to communicate with the team, please [join u
 - [Mentorship and Growth](#mentorship-and-growth)
 - [Learning the tech stack](#learning-the-tech)
 - [Development environment](#development-environment)
+- [Testing](#testing)
 - [Issues and projects](#issues-and-projects)
 - [Bug reports](#bug-reports)
 - [Feature requests](#feature-requests)
@@ -179,6 +180,26 @@ After adding this line, remember to apply the changes by sourcing the file (e.g.
 
 > [!NOTE]
 > Feel free to contact the team in the [Data room on Matrix](https://matrix.to/#/#ScribeData:matrix.org) if you're having problems getting your environment setup!
+
+<sub><a href="#top">Back to top.</a></sub>
+
+## Testing
+
+Run the complete test suite from the repository root before opening a pull request:
+
+```bash
+make test
+```
+
+To run the tests and show coverage by package and function, use:
+
+```bash
+make test-cover
+```
+
+This writes `coverage.out`, which is ignored by Git. Test pull requests should include the total coverage before and after the change, for example `Coverage: 0.4% -> 1.1%`. Coverage should increase as the test suite grows; if it does not, explain why in the pull request.
+
+See [TESTING.md](./TESTING.md) for the project's test organization, naming, isolation, and fixture conventions.
 
 <sub><a href="#top">Back to top.</a></sub>
 

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: clean build test run fmt tidy install-tools generate generate-api generate-db execute-binary dev docs docs-serve migrate build-migrate update-data install-hooks lint
+.PHONY: clean build test test-cover run fmt tidy install-tools generate generate-api generate-db execute-binary dev docs docs-serve migrate build-migrate update-data install-hooks lint
 
 BINARY_NAME=./bin/scribe-server
 MIGRATE_BINARY=./bin/migrate-scribe-data
@@ -19,6 +19,11 @@ build:
 # Run tests for the project.
 test:
 	go test ./... -v
+
+# Run tests and report coverage by function.
+test-cover:
+	go test ./... -coverprofile=coverage.out
+	go tool cover -func=coverage.out
 
 # Run the project (defaults to dev).
 run: run-dev

--- a/TESTING.md
+++ b/TESTING.md
@@ -2,6 +2,17 @@
 
 Scribe-Server uses Go's standard `testing` package, with `testify` for assertions. These conventions keep the test suite consistent as coverage is added incrementally.
 
+## Contents
+
+- [Organizing tests](#organizing-tests)
+- [Assertions and helpers](#assertions-and-helpers)
+- [Isolating global state](#isolating-global-state)
+- [HTTP handlers](#http-handlers)
+- [Databases and fixtures](#databases-and-fixtures)
+- [Running tests and coverage](#running-tests-and-coverage)
+- [Local verification before committing](#local-verification-before-committing)
+- [Pull request checklist](#pull-request-checklist)
+
 ## Organizing tests
 
 - Keep tests beside the code they cover in package-local `*_test.go` files. Do not create a separate top-level test directory.
@@ -49,6 +60,8 @@ func TestIsValidTranslationLangCode(t *testing.T) {
 }
 ```
 
+<sub><a href="#top">Back to top.</a></sub>
+
 ## Assertions and helpers
 
 - Use `require` when a failed check must stop the current test or subtest, such as failed setup, an unexpected error, or a required response body.
@@ -78,6 +91,8 @@ func TestErrorResponseFixture(t *testing.T) {
 	assert.Equal(t, "invalid language code", response.Error)
 }
 ```
+
+<sub><a href="#top">Back to top.</a></sub>
 
 ## Isolating global state
 
@@ -121,6 +136,8 @@ func TestConfigUsesTestEnvironment(t *testing.T) {
 }
 ```
 
+<sub><a href="#top">Back to top.</a></sub>
+
 ## HTTP handlers
 
 - Test Gin handlers with `net/http/httptest`; a running server is not required.
@@ -153,6 +170,8 @@ func TestHandleError(t *testing.T) {
 	assert.Equal(t, "invalid language code", response.Error)
 }
 ```
+
+<sub><a href="#top">Back to top.</a></sub>
 
 ## Databases and fixtures
 
@@ -232,6 +251,8 @@ Run explicitly tagged integration tests only after preparing an isolated databas
 go test -tags=integration ./database/...
 ```
 
+<sub><a href="#top">Back to top.</a></sub>
+
 ## Running tests and coverage
 
 Run all tests before opening a pull request:
@@ -251,6 +272,8 @@ For an HTML coverage report after running `make test-cover`:
 ```bash
 go tool cover -html=coverage.out
 ```
+
+<sub><a href="#top">Back to top.</a></sub>
 
 ## Local verification before committing
 
@@ -292,6 +315,8 @@ Pull requests that add tests should report the total coverage before and after t
 
 CI runs the same coverage target. A test must not rely on local configuration, network access, execution order, or files outside the repository.
 
+<sub><a href="#top">Back to top.</a></sub>
+
 ## Pull request checklist
 
 - Tests follow the package, naming, and table-driven conventions above.
@@ -300,3 +325,5 @@ CI runs the same coverage target. A test must not rely on local configuration, n
 - `make test` passes locally.
 - `make test-cover` passes locally.
 - The pull request includes the before and after total coverage.
+
+<sub><a href="#top">Back to top.</a></sub>

--- a/TESTING.md
+++ b/TESTING.md
@@ -1,0 +1,302 @@
+# Testing conventions
+
+Scribe-Server uses Go's standard `testing` package, with `testify` for assertions. These conventions keep the test suite consistent as coverage is added incrementally.
+
+## Organizing tests
+
+- Keep tests beside the code they cover in package-local `*_test.go` files. Do not create a separate top-level test directory.
+- Use the same package name as the code when a test needs package-private access. Use an external `<package>_test` package when testing only the public API provides useful separation.
+- Name test files after the source or behavior they cover, such as `language_validator_test.go`.
+- Name top-level tests `Test<Subject>` or `Test<Subject>_<Scenario>`. Use descriptive subtest names for individual cases.
+- Prefer table-driven tests with `t.Run` when several cases share the same setup and assertion structure.
+
+For example, tests for the language validator stay in the same directory as the production code:
+
+```text
+api/validators/
+├── language_validator.go
+└── language_validator_test.go
+```
+
+`language_validator_test.go` can use the same `validators` package and group related inputs in a table:
+
+```go
+package validators
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestIsValidTranslationLangCode(t *testing.T) {
+	tests := []struct {
+		name string
+		code string
+		want bool
+	}{
+		{name: "two-letter code", code: "de", want: true},
+		{name: "three-letter code", code: "pnb", want: true},
+		{name: "uppercase code", code: "DE", want: false},
+		{name: "empty code", code: "", want: false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.want, IsValidTranslationLangCode(tt.code))
+		})
+	}
+}
+```
+
+## Assertions and helpers
+
+- Use `require` when a failed check must stop the current test or subtest, such as failed setup, an unexpected error, or a required response body.
+- Use `assert` when later checks are still meaningful after a failure.
+- Mark reusable test helpers with `t.Helper()` so failures point to the calling test.
+- Register teardown with `t.Cleanup` as soon as a test acquires a resource.
+- Use `t.Setenv` for test-specific environment variables and `t.TempDir` for temporary files. Do not depend on a contributor's machine, home directory, or persistent files.
+
+In this example, a missing or invalid fixture stops the test with `require`; once setup succeeds, `assert` checks independent properties and reports all mismatches:
+
+```go
+func readFixture(t *testing.T, name string) []byte {
+	t.Helper()
+
+	data, err := os.ReadFile(filepath.Join("testdata", name))
+	require.NoError(t, err)
+	return data
+}
+
+func TestErrorResponseFixture(t *testing.T) {
+	data := readFixture(t, "error_response.json")
+
+	var response models.ErrorResponse
+	require.NoError(t, json.Unmarshal(data, &response))
+
+	assert.NotEmpty(t, response.Error)
+	assert.Equal(t, "invalid language code", response.Error)
+}
+```
+
+## Isolating global state
+
+Tests must be independent and produce the same result in any order.
+
+- Put Gin in test mode when testing routes or handlers. Restore its prior mode with `t.Cleanup` when a test changes it.
+- Prefer a new Viper instance created with `viper.New()` over package-level Viper state. If production code requires the global instance, call `viper.Reset()` during setup and cleanup.
+- Do not call `t.Parallel()` in tests that mutate Gin mode, global Viper state, package globals, process-wide environment, or shared storage.
+- Avoid real clocks, random results, external networks, and order-dependent assertions. Inject or fix those inputs when they affect behavior.
+
+Use a helper to make the lifecycle obvious. A test that calls this helper must not call `t.Parallel()`:
+
+```go
+func isolateGlobalState(t *testing.T) *viper.Viper {
+	t.Helper()
+
+	previousMode := gin.Mode()
+	gin.SetMode(gin.TestMode)
+	t.Cleanup(func() {
+		gin.SetMode(previousMode)
+	})
+
+	// Prefer this isolated instance when production code accepts one.
+	config := viper.New()
+	config.Set("GIN_MODE", "test")
+
+	// If the code under test uses package-level Viper state, reset it both
+	// before and after the test so another test cannot influence this one.
+	viper.Reset()
+	t.Cleanup(viper.Reset)
+
+	return config
+}
+
+func TestConfigUsesTestEnvironment(t *testing.T) {
+	config := isolateGlobalState(t)
+	t.Setenv("ENV", "test")
+
+	assert.Equal(t, "test", os.Getenv("ENV"))
+	assert.Equal(t, "test", config.GetString("GIN_MODE"))
+}
+```
+
+## HTTP handlers
+
+- Test Gin handlers with `net/http/httptest`; a running server is not required.
+- Build the smallest router needed for the behavior under test.
+- Assert the HTTP status, relevant headers, and decoded response body.
+- Replace databases, files, and external services with isolated dependencies where the production design permits it.
+
+For example, `HandleError` can be exercised through a minimal Gin router and an in-memory response recorder:
+
+```go
+func TestHandleError(t *testing.T) {
+	previousMode := gin.Mode()
+	gin.SetMode(gin.TestMode)
+	t.Cleanup(func() { gin.SetMode(previousMode) })
+
+	router := gin.New()
+	router.GET("/test", func(c *gin.Context) {
+		HandleError(c, http.StatusBadRequest, "invalid language code")
+	})
+
+	request := httptest.NewRequest(http.MethodGet, "/test", nil)
+	recorder := httptest.NewRecorder()
+	router.ServeHTTP(recorder, request)
+
+	require.Equal(t, http.StatusBadRequest, recorder.Code)
+	assert.Equal(t, "application/json; charset=utf-8", recorder.Header().Get("Content-Type"))
+
+	var response models.ErrorResponse
+	require.NoError(t, json.NewDecoder(recorder.Body).Decode(&response))
+	assert.Equal(t, "invalid language code", response.Error)
+}
+```
+
+## Databases and fixtures
+
+- Keep unit tests independent of MariaDB and other external services.
+- Treat a test that requires a database as an integration test. Give it isolated setup and teardown, and document how to run it.
+- Do not make the default unit-test suite depend on a developer's local database or existing data.
+- Store static fixtures in a `testdata/` directory next to the package that uses them. Keep small expected values inline when that makes the test easier to read.
+- Never modify a checked-in fixture during a test. Copy it to `t.TempDir()` first when mutation is required.
+
+For example, contract fixtures used by handler tests belong to the handler package:
+
+```text
+api/handlers/
+├── language.go
+├── language_test.go
+└── testdata/
+    └── de.yaml
+```
+
+Use a helper like this when a test needs to pass a writable fixture to production code:
+
+```go
+func writableFixture(t *testing.T, name string) string {
+	t.Helper()
+
+	source := filepath.Join("testdata", name)
+	data, err := os.ReadFile(source)
+	require.NoError(t, err)
+
+	destination := filepath.Join(t.TempDir(), filepath.Base(name))
+	require.NoError(t, os.WriteFile(destination, data, 0o600))
+	return destination
+}
+
+func TestLoadSingleContract(t *testing.T) {
+	contractPath := writableFixture(t, "de.yaml")
+
+	contract, err := loadSingleContract(filepath.Dir(contractPath), "de")
+	require.NoError(t, err)
+	assert.Contains(t, contract, "de")
+
+	// The checked-in testdata/de.yaml file remains unchanged.
+}
+```
+
+Database integration tests should be clearly separated from the default unit suite. For example, put this build constraint at the top of `connection_integration_test.go`:
+
+```go
+//go:build integration
+
+package database
+
+import (
+	"database/sql"
+	"os"
+	"testing"
+
+	_ "github.com/go-sql-driver/mysql"
+	"github.com/stretchr/testify/require"
+)
+
+func TestDatabaseConnection_Integration(t *testing.T) {
+	dsn := os.Getenv("SCRIBE_TEST_DATABASE_DSN")
+	require.NotEmpty(t, dsn, "set SCRIBE_TEST_DATABASE_DSN to an isolated test database")
+
+	db, err := sql.Open("mysql", dsn)
+	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, db.Close()) })
+
+	require.NoError(t, db.Ping())
+}
+```
+
+Run explicitly tagged integration tests only after preparing an isolated database:
+
+```bash
+go test -tags=integration ./database/...
+```
+
+## Running tests and coverage
+
+Run all tests before opening a pull request:
+
+```bash
+make test
+```
+
+Generate `coverage.out` and print coverage by function:
+
+```bash
+make test-cover
+```
+
+For an HTML coverage report after running `make test-cover`:
+
+```bash
+go tool cover -html=coverage.out
+```
+
+## Local verification before committing
+
+Changes to Go code or the testing infrastructure should not introduce unexpected dependency changes. Run:
+
+```bash
+go mod tidy
+git diff --exit-code go.mod go.sum
+```
+
+If `go mod tidy` changes `go.mod` or `go.sum` unexpectedly, inspect why before committing. Keep intentional dependency changes and explain them in the pull request.
+
+Run formatting and lint checks as well:
+
+```bash
+make fmt
+make lint
+```
+
+The lint target requires [`revive`](https://github.com/mgechev/revive). If it is not installed, the Makefile prints the installation command.
+
+A complete local verification sequence is:
+
+```bash
+git status
+
+make fmt
+make test
+make test-cover
+make lint
+
+go tool cover -func=coverage.out | tail -1
+
+git status
+git diff
+```
+
+Pull requests that add tests should report the total coverage before and after the change, for example `Coverage: 3.4% -> 5.1%`. Coverage should increase incrementally. If it does not, explain why in the pull request.
+
+CI runs the same coverage target. A test must not rely on local configuration, network access, execution order, or files outside the repository.
+
+## Pull request checklist
+
+- Tests follow the package, naming, and table-driven conventions above.
+- Success, failure, and relevant edge cases are covered.
+- Test state and resources are isolated and cleaned up.
+- `make test` passes locally.
+- `make test-cover` passes locally.
+- The pull request includes the before and after total coverage.

--- a/TESTING.md
+++ b/TESTING.md
@@ -1,3 +1,5 @@
+<a id="top"></a>
+
 # Testing conventions
 
 Scribe-Server uses Go's standard `testing` package, with `testify` for assertions. These conventions keep the test suite consistent as coverage is added incrementally.


### PR DESCRIPTION
<!---
Thank you for your pull request! 🚀
-->

### Contributor checklist

<!-- Please replace the empty checkboxes [] below with checked ones [x] accordingly. -->

- [x] This pull request is on a [separate branch](https://docs.github.com/en/get-started/quickstart/github-flow) and not the main branch
- [x] I have ran the `./pre-commit` executable as well as `make lint` and have fixed all reported issues

---

### Description

<!--
Describe briefly what your pull request proposes to change. Especially if you have more than one commit, it is helpful to give a summary of what your contribution is trying to solve.

Also consider including the following:
- A description of the main files changed and what has been done in them (helps maintainers focus their review)
- A description of how you tested that your change actually works
- Pictures or a video of your change (if possible)
-->
This pull request establishes a consistent testing convention and harness for Scribe-Server so that future test contributions follow the same structure and workflow.

Main changes include:

- Added `TESTING.md` to document the project-wide testing conventions.
- Defined conventions for package-local `*_test.go` files, table-driven tests, `t.Run`, and `testify` assertions.
- Documented how to test Gin handlers using `httptest` without running the server.
- Defined unit-test isolation rules so tests do not depend on a local MariaDB instance, production configuration, or external services.
- Added a `make test-cover` command for generating and displaying coverage results.
- Updated `CONTRIBUTING.md` with testing instructions and a link to the full testing guide.
- Updated the PR CI workflow to use `go mod download`, run the coverage command through the Makefile, and trigger when testing-related files are modified.

### Related issue

<!--- Scribe-Server prefers that pull requests be related to already open issues. -->
<!--- If applicable, please link to the issue by replacing ISSUE_NUMBER with the appropriate number below. -->
<!--- You can also put "Closes" before the # to close the issue on merge, or say there is no related issue. -->

- closes #83 
